### PR TITLE
Fix: Path conversion missing underscore handling for Claude Code session directories #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Japanese translations for all redo-related messages
 - Enhanced prompt translations for redo confirmations
 
+## [1.1.1] - 2025-07-09
+
+### Fixed
+- **Critical Bug Fix**: Fixed ccundo list command failing in directories with underscores in their names
+- Updated path conversion regex in ClaudeSessionParser to handle underscores correctly
+- Changed regex from `/[\s\/]/g` to `/[\s\/_]/g` to match Claude Code's directory naming convention
+
+### Technical Details
+- Directories like `/home/user/my_project_name` now correctly map to `-home-user-my-project-name`
+- Maintains backward compatibility with existing functionality
+- All ccundo commands now work properly in directories containing underscores
+
 ## [Unreleased]
 
 ### Planned Features

--- a/bin/ccundo.js
+++ b/bin/ccundo.js
@@ -21,7 +21,7 @@ const program = new Command();
 program
   .name('ccundo')
   .description('Undo individual steps performed by Claude Code within a session')
-  .version('1.1.0');
+  .version('1.1.1');
 
 program
   .command('list')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccundo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Intelligent undo for Claude Code sessions - Revert individual operations with cascading safety and detailed previews",
   "main": "index.js",
   "bin": {

--- a/src/core/ClaudeSessionParser.js
+++ b/src/core/ClaudeSessionParser.js
@@ -12,8 +12,8 @@ export class ClaudeSessionParser {
 
   async getCurrentProjectDir() {
     const cwd = process.cwd();
-    // Replace all forward slashes with dashes and spaces with dashes too
-    const safePath = cwd.replace(/[\s\/]/g, '-');
+    // Replace all forward slashes, spaces, and underscores with dashes
+    const safePath = cwd.replace(/[\s\/_]/g, '-');
     return path.join(this.claudeProjectsDir, safePath);
   }
 


### PR DESCRIPTION
## Bug Description

The `ccundo list` command failed to work in directories containing underscores in their names (e.g., `my_project_name`).

## Root Cause

The `getCurrentProjectDir()` method in `ClaudeSessionParser.js` only converted forward slashes and spaces to dashes, but Claude Code also converts underscores to dashes when creating session directories.

**What ccundo was doing:**
```
/home/user/projects/my_project_name 
→ -home-user-projects-my_project_name
```

**What Claude Code actually creates:**
```
/home/user/projects/my_project_name 
→ -home-user-projects-my-project-name
```

## Fix Applied

Updated the regex in `getCurrentProjectDir()` from:
```javascript
const safePath = cwd.replace(/[\s\/]/g, '-');
```

To:
```javascript
const safePath = cwd.replace(/[\s\/_]/g, '-');
```

## Impact

- ✅ `ccundo list` now works in directories with underscores
- ✅ All other ccundo commands now work in directories with underscores
- ✅ Maintains backward compatibility with existing functionality

## Testing

Verified the fix works correctly by testing path conversion for directories containing underscores.