### PR TITLE
feature: cross-platform compatibility

### DIFF
--- a/bin/ccundo.js
+++ b/bin/ccundo.js
@@ -12,6 +12,7 @@ import { OperationPreview } from '../src/core/OperationPreview.js';
 import { i18n } from '../src/i18n/i18n.js';
 import { UndoTracker } from '../src/core/UndoTracker.js';
 import { RedoManager } from '../src/core/RedoManager.js';
+import path from 'path';
 
 // Initialize i18n
 await i18n.init();
@@ -549,9 +550,11 @@ program
         
         console.log(chalk.bold('\nAvailable Claude Code sessions:\n'));
         
-        const currentDir = process.cwd();
+        const currentProjectDir = await parser.getCurrentProjectDir();
+        const currentProjectDirName = path.basename(currentProjectDir);
+
         sessions.forEach(session => {
-          const isCurrent = session.project === currentDir;
+          const isCurrent = session.rawProjectDir === currentProjectDirName;
           const marker = isCurrent ? chalk.green('→ ') : '  ';
           console.log(`${marker}${chalk.cyan(session.id)}`);
           console.log(`  Project: ${session.project}`);

--- a/src/core/RedoManager.js
+++ b/src/core/RedoManager.js
@@ -1,10 +1,11 @@
 import fs from 'fs/promises';
 import path from 'path';
+import os from 'os';
 import { OperationType } from './Operation.js';
 
 export class RedoManager {
   constructor() {
-    this.backupDir = path.join(process.env.HOME, '.ccundo', 'backups');
+    this.backupDir = path.join(os.homedir(), '.ccundo', 'backups');
   }
 
   async init() {

--- a/src/core/SessionTracker.js
+++ b/src/core/SessionTracker.js
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+import os from 'os';
 import { Operation, OperationType } from './Operation.js';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
@@ -11,7 +12,7 @@ export class SessionTracker {
   constructor(sessionId = null) {
     this.sessionId = sessionId || new Date().toISOString().replace(/[:.]/g, '-');
     this.operations = [];
-    this.sessionDir = path.join(process.env.HOME, '.ccundo', 'sessions');
+    this.sessionDir = path.join(os.homedir(), '.ccundo', 'sessions');
     this.sessionFile = path.join(this.sessionDir, `${this.sessionId}.json`);
   }
 
@@ -65,7 +66,7 @@ export class SessionTracker {
   }
 
   static async listSessions() {
-    const sessionDir = path.join(process.env.HOME, '.ccundo', 'sessions');
+    const sessionDir = path.join(os.homedir(), '.ccundo', 'sessions');
     try {
       const files = await fs.readdir(sessionDir);
       return files
@@ -80,7 +81,7 @@ export class SessionTracker {
   }
 
   static async getCurrentSession() {
-    const currentFile = path.join(process.env.HOME, '.ccundo', 'current-session');
+    const currentFile = path.join(os.homedir(), '.ccundo', 'current-session');
     try {
       const sessionId = await fs.readFile(currentFile, 'utf8');
       return sessionId.trim();
@@ -90,7 +91,7 @@ export class SessionTracker {
   }
 
   static async setCurrentSession(sessionId) {
-    const currentFile = path.join(process.env.HOME, '.ccundo', 'current-session');
+    const currentFile = path.join(os.homedir(), '.ccundo', 'current-session');
     await fs.mkdir(path.dirname(currentFile), { recursive: true });
     await fs.writeFile(currentFile, sessionId);
   }

--- a/src/core/UndoManager.js
+++ b/src/core/UndoManager.js
@@ -1,10 +1,11 @@
 import fs from 'fs/promises';
 import path from 'path';
+import os from 'os';
 import { OperationType } from './Operation.js';
 
 export class UndoManager {
   constructor() {
-    this.backupDir = path.join(process.env.HOME, '.ccundo', 'backups');
+    this.backupDir = path.join(os.homedir(), '.ccundo', 'backups');
   }
 
   async init() {

--- a/src/core/UndoTracker.js
+++ b/src/core/UndoTracker.js
@@ -1,9 +1,10 @@
 import fs from 'fs/promises';
 import path from 'path';
+import os from 'os';
 
 export class UndoTracker {
   constructor() {
-    this.undoFile = path.join(process.env.HOME, '.ccundo', 'undone-operations.json');
+    this.undoFile = path.join(os.homedir(), '.ccundo', 'undone-operations.json');
   }
 
   async init() {

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -1,11 +1,12 @@
 import fs from 'fs/promises';
 import path from 'path';
+import os from 'os';
 import { languages } from './languages.js';
 
 class I18n {
   constructor() {
     this.currentLanguage = 'en';
-    this.configFile = path.join(process.env.HOME, '.ccundo', 'config.json');
+    this.configFile = path.join(os.homedir(), '.ccundo', 'config.json');
   }
 
   async init() {


### PR DESCRIPTION
## Cross-Platform Compatibility & Environment Improvements

### Summary

This pull request refactors all usages of process.env.HOME to use os.homedir() for improved cross-platform compatibility (Windows, macOS, Linux). It also updates project directory encoding/decoding logic to handle platform-specific path formats, ensuring correct session management and file operations on all major operating systems.

### Changes
 - Environment Variables:
  Replaced all instances of process.env.HOME with os.homedir() in:

    - ccundo.js
    - ClaudeSessionParser.js
    - RedoManager.js
    - SessionTracker.js
    - UndoManager.js
    - UndoTracker.js
    - i18n.js

- Session Path Encoding/Decoding:

  - Updated ClaudeSessionParser to encode/decode project paths differently for Windows and POSIX systems.
  - Ensures session directories and project names are correctly recognized and displayed regardless of OS.

- Session Listing:
    - Improved logic for marking the current session in the CLI output, using raw directory names for reliable comparison.
   
- Motivation
  - Fixes issues where ccundo would fail or behave unexpectedly on Windows due to incorrect home directory resolution and path formatting.
  - Makes the tool robust for all users, regardless of their operating system.
 
- Testing
  - Verified on Windows, Linux (WSL Debian) and macOS:
    - [x] Session listing, undo/redo, and language configuration work as expected.
    - [x] No errors related to home directory or path handling.
- Additional Notes
  - No breaking changes to the CLI or API.
