### PR TITLE
feat(i18n): complete internationalization based on Chinese translation from PR #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ccundo seamlessly integrates with Claude Code to provide granular undo and redo 
 - **Detailed Previews** - See exactly what will be changed before undoing/redoing
 - **Cascading Undo/Redo** - Maintains project consistency by undoing/redoing dependent operations
 - **Complete Redo System** - Reverse any undo operation with full cascading support
-- **Multi-language** - Supports English and Japanese (日本語)
+- **Multi-language** - Supports English, Japanese (日本語), French (Français), Spanish (Español), German (Deutsch), Simplified Chinese (简体中文), and Traditional Chinese (繁體中文)
 - **Smart Operation Tracking** - Tracks file edits, creations, deletions, renames, and bash commands
 - **Safe Backups** - Creates backups before making changes
 - **Zero Configuration** - Works out of the box with Claude Code
@@ -131,6 +131,8 @@ ccundo language ja           # Switch to Japanese (日本語)
 ccundo language fr           # Switch to French (Français)
 ccundo language es           # Switch to Spanish (Español)
 ccundo language de           # Switch to German (Deutsch)
+ccundo language zh           # Switch to Simplified Chinese (简体中文)
+ccundo language tw           # Switch to Traditional Chinese (繁體中文)
 ```
 
 **Supported Languages:**
@@ -139,6 +141,8 @@ ccundo language de           # Switch to German (Deutsch)
 - 🇫🇷 French (`fr`) - Français
 - 🇪🇸 Spanish (`es`) - Español
 - 🇩🇪 German (`de`) - Deutsch
+- 🇨🇳 Simplified Chinese (`zh`) - 简体中文支持
+- 🇹🇼 Traditional Chinese (`tw`) - 繁體中文支援
 
 ## How It Works
 

--- a/bin/ccundo.js
+++ b/bin/ccundo.js
@@ -6,7 +6,6 @@ import inquirer from 'inquirer';
 import { SessionTracker } from '../src/core/SessionTracker.js';
 import { UndoManager } from '../src/core/UndoManager.js';
 import { formatDistance } from '../src/utils/formatting.js';
-import { Operation, OperationType } from '../src/core/Operation.js';
 import { ClaudeSessionParser } from '../src/core/ClaudeSessionParser.js';
 import { OperationPreview } from '../src/core/OperationPreview.js';
 import { i18n } from '../src/i18n/i18n.js';
@@ -21,7 +20,7 @@ const program = new Command();
 
 program
   .name('ccundo')
-  .description('Undo individual steps performed by Claude Code within a session')
+  .description(i18n.t('program.description'))
   .version('1.1.1');
 
 program
@@ -41,70 +40,70 @@ program
         const sessionFile = await parser.getCurrentSessionFile();
         
         if (!sessionFile) {
-          console.log(chalk.yellow('No active Claude Code session found in this directory.'));
-          console.log(chalk.gray('Make sure you are in a directory where Claude Code has been used.'));
+          console.log(chalk.yellow(i18n.t('msg.no_active_session')));
+          console.log(chalk.gray(i18n.t('msg.make_sure_directory')));
           return;
         }
         
         operations = await parser.parseSessionFile(sessionFile);
-        console.log(chalk.bold(`\nOperations from Claude Code session:\n`));
+        console.log(chalk.bold(`\n${i18n.t('header.operations_claude')}\n`));
       } else {
         // Use local ccundo tracking
         const sessionId = options.session || await SessionTracker.getCurrentSession();
         if (!sessionId) {
-          console.log(chalk.yellow('No local ccundo session found.'));
+          console.log(chalk.yellow(i18n.t('msg.no_local_session')));
           return;
         }
 
         const tracker = new SessionTracker(sessionId);
         await tracker.init();
         operations = await tracker.getOperations(options.all);
-        console.log(chalk.bold(`\nOperations in local session ${sessionId}:\n`));
+        console.log(chalk.bold(`\n${i18n.t('header.operations_local', { sessionId })}\n`));
       }
       
       if (operations.length === 0) {
-        console.log(chalk.yellow('No operations found.'));
+        console.log(chalk.yellow(i18n.t('msg.no_operations')));
         return;
       }
 
       operations.forEach((op, index) => {
-        const status = op.undone ? chalk.red('[UNDONE]') : chalk.green('[ACTIVE]');
+        const status = op.undone ? chalk.red(i18n.t('status.undone')) : chalk.green(i18n.t('status.active'));
         const time = formatDistance(op.timestamp);
         
-        console.log(`${index + 1}. ${status} ${chalk.cyan(op.type)} - ${time}`);
+        console.log(`${index + 1}. ${status} ${chalk.cyan(i18n.t(`op.${op.type}`))} - ${time}`);
         console.log(`   ID: ${op.id}`);
         
         switch (op.type) {
           case 'file_create':
           case 'file_edit':
           case 'file_delete':
-            console.log(`   File: ${op.data.filePath}`);
+            console.log(`   ${i18n.t('label.file')}: ${op.data.filePath}`);
             break;
           case 'file_rename':
-            console.log(`   From: ${op.data.oldPath}`);
-            console.log(`   To: ${op.data.newPath}`);
+            console.log(`   ${i18n.t('label.from')}: ${op.data.oldPath}`);
+            console.log(`   ${i18n.t('label.to')}: ${op.data.newPath}`);
             break;
           case 'directory_create':
           case 'directory_delete':
-            console.log(`   Directory: ${op.data.dirPath}`);
+            console.log(`   ${i18n.t('label.directory')}: ${op.data.dirPath}`);
             break;
           case 'bash_command':
-            console.log(`   Command: ${op.data.command}`);
+            console.log(`   ${i18n.t('label.command')}: ${op.data.command}`);
             break;
         }
         console.log('');
       });
     } catch (error) {
-      console.error(chalk.red(`Error: ${error.message}`));
+      console.error(chalk.red(i18n.t('error.general', { message: error.message })));
     }
   });
 
 program
   .command('undo [operation-id]')
-  .description('Undo operations from the current Claude Code session')
-  .option('-s, --session <id>', 'Specify session ID')
-  .option('-y, --yes', 'Skip confirmation')
-  .option('--local', 'Use local ccundo tracking instead of Claude sessions')
+  .description(i18n.t('cmd.undo.description'))
+  .option('-s, --session <id>', i18n.t('opt.session'))
+  .option('-y, --yes', i18n.t('opt.yes'))
+  .option('--local', i18n.t('opt.local_tracking'))
   .action(async (operationId, options) => {
     try {
       let operations = [];
@@ -114,7 +113,7 @@ program
         // Use local ccundo tracking
         const sessionId = options.session || await SessionTracker.getCurrentSession();
         if (!sessionId) {
-          console.log(chalk.yellow('No local ccundo session found.'));
+          console.log(chalk.yellow(i18n.t('msg.no_local_session')));
           return;
         }
 
@@ -127,7 +126,7 @@ program
         sessionFile = await parser.getCurrentSessionFile();
         
         if (!sessionFile) {
-          console.log(chalk.yellow('No active Claude Code session found in this directory.'));
+          console.log(chalk.yellow(i18n.t('msg.no_active_session')));
           return;
         }
         
@@ -135,7 +134,7 @@ program
       }
       
       if (operations.length === 0) {
-        console.log(chalk.yellow('No operations to undo.'));
+        console.log(chalk.yellow(i18n.t('msg.no_operations_to_undo')));
         return;
       }
 
@@ -150,7 +149,7 @@ program
           let name = `${op.type} - ${formatDistance(op.timestamp)}`;
           
           if (operationsToUndo > 1) {
-            name += chalk.red(` (+ ${operationsToUndo - 1} more will be undone)`);
+            name += chalk.red(i18n.t('ui.more_will_be_undone', { count: operationsToUndo - 1 }));
           }
           
           return {
@@ -160,12 +159,12 @@ program
           };
         });
         
-        console.log(chalk.yellow('\\n⚠️  Cascading undo: Selecting an operation will undo it and ALL operations that came after it.\\n'));
+        console.log(chalk.yellow(`\\n${i18n.t('prompt.cascading_warning')}\\n`));
         
         const answer = await inquirer.prompt([{
           type: 'list',
           name: 'selectedIndex',
-          message: 'Select operation to undo:',
+          message: i18n.t('prompt.select_operation_undo'),
           choices: choices,
           pageSize: 15
         }]);
@@ -174,7 +173,7 @@ program
       } else {
         selectedIndex = operations.findIndex(op => op.id === operationId);
         if (selectedIndex === -1) {
-          console.log(chalk.red(`Operation ${operationId} not found.`));
+          console.log(chalk.red(i18n.t('error.operation_not_found', { id: operationId })));
           return;
         }
       }
@@ -182,7 +181,7 @@ program
       const operationsToUndo = operations.slice(0, selectedIndex + 1);
       
       if (!options.yes) {
-        console.log(chalk.yellow(`\\nThis will undo ${operationsToUndo.length} operation(s):\\n`));
+        console.log(chalk.yellow(`\\n${i18n.t('ui.undo_preview_header', { count: operationsToUndo.length })}\\n`));
         
         for (let i = 0; i < operationsToUndo.length; i++) {
           const op = operationsToUndo[i];
@@ -196,12 +195,12 @@ program
         const confirm = await inquirer.prompt([{
           type: 'confirm',
           name: 'proceed',
-          message: `Are you sure you want to undo these ${operationsToUndo.length} operations?`,
+          message: i18n.t('prompt.confirm_undo', { count: operationsToUndo.length }),
           default: false
         }]);
         
         if (!confirm.proceed) {
-          console.log(chalk.yellow('Undo cancelled.'));
+          console.log(chalk.yellow(i18n.t('msg.undo_cancelled')));
           return;
         }
       }
@@ -212,7 +211,7 @@ program
       const undoTracker = new UndoTracker();
       await undoTracker.init();
       
-      console.log(chalk.cyan(`\\nUndoing ${operationsToUndo.length} operations...\\n`));
+      console.log(chalk.cyan(`\\n${i18n.t('ui.undoing_operations', { count: operationsToUndo.length })}\\n`));
       
       let successCount = 0;
       let failCount = 0;
@@ -224,7 +223,7 @@ program
           successCount++;
           console.log(chalk.green(`✓ ${result.message}`));
           if (result.backupPath) {
-            console.log(chalk.gray(`  Backup saved to: ${result.backupPath}`));
+            console.log(chalk.gray(`  ${i18n.t('msg.backup_saved_to', { path: result.backupPath })}`));
           }
           
           // Mark operation as undone if using Claude Code sessions
@@ -237,10 +236,10 @@ program
         }
       }
       
-      console.log(chalk.bold(`\\nCompleted: ${chalk.green(successCount)} successful, ${chalk.red(failCount)} failed`));
+      console.log(chalk.bold(`\\n${i18n.t('status.completed', { success: chalk.green(successCount), failed: chalk.red(failCount) })}`));
       
     } catch (error) {
-      console.error(chalk.red(`Error: ${error.message}`));
+      console.error(chalk.red(i18n.t('error.general', { message: error.message })));
     }
   });
 
@@ -249,7 +248,7 @@ program
   .description(i18n.t('cmd.redo.description'))
   .option('-s, --session <id>', i18n.t('opt.session'))
   .option('-y, --yes', i18n.t('opt.yes'))
-  .option('--local', 'Use local ccundo tracking instead of Claude sessions')
+  .option('--local', i18n.t('opt.local_tracking'))
   .action(async (operationId, options) => {
     try {
       let operations = [];
@@ -259,14 +258,14 @@ program
         // Use local ccundo tracking
         const sessionId = options.session || await SessionTracker.getCurrentSession();
         if (!sessionId) {
-          console.log(chalk.yellow('No local ccundo session found.'));
+          console.log(chalk.yellow(i18n.t('msg.no_local_session')));
           return;
         }
 
         const tracker = new SessionTracker(sessionId);
         await tracker.init();
         // For local tracking, we'd need to implement redo tracking
-        console.log(chalk.yellow('Redo for local tracking is not yet implemented.'));
+        console.log(chalk.yellow(i18n.t('msg.redo_not_implemented')));
         return;
       } else {
         // Use Claude Code sessions
@@ -274,7 +273,7 @@ program
         sessionFile = await parser.getCurrentSessionFile();
         
         if (!sessionFile) {
-          console.log(chalk.yellow('No active Claude Code session found in this directory.'));
+          console.log(chalk.yellow(i18n.t('msg.no_active_session')));
           return;
         }
         
@@ -333,7 +332,7 @@ program
           let name = `${op.type} - ${formatDistance(op.timestamp)}`;
           
           if (operationsToRedo > 1) {
-            name += chalk.green(` (+ ${operationsToRedo - 1} more will be redone)`);
+            name += chalk.green(i18n.t('ui.more_will_be_redone', { count: operationsToRedo - 1 }));
           }
           
           return {
@@ -343,7 +342,7 @@ program
           };
         });
         
-        console.log(chalk.yellow('\\n⚠️  Cascading redo: Selecting an operation will redo it and ALL undone operations that came before it.\\n'));
+        console.log(chalk.yellow(`\\n${i18n.t('prompt.cascading_redo_warning')}\\n`));
         
         const answer = await inquirer.prompt([{
           type: 'list',
@@ -357,7 +356,7 @@ program
       } else {
         selectedIndex = operations.findIndex(op => op.id === operationId);
         if (selectedIndex === -1) {
-          console.log(chalk.red(`Operation ${operationId} not found.`));
+          console.log(chalk.red(i18n.t('error.operation_not_found', { id: operationId })));
           return;
         }
       }
@@ -381,7 +380,7 @@ program
         }]);
         
         if (!confirm.proceed) {
-          console.log(chalk.yellow('Redo cancelled.'));
+          console.log(chalk.yellow(i18n.t('msg.redo_cancelled')));
           return;
         }
       }
@@ -405,7 +404,7 @@ program
           successCount++;
           console.log(chalk.green(`✓ ${result.message}`));
           if (result.backupPath) {
-            console.log(chalk.gray(`  Backup saved to: ${result.backupPath}`));
+            console.log(chalk.gray(`  ${i18n.t('msg.backup_saved_to', { path: result.backupPath })}`));
           }
           
           // Mark operation as redone (remove from undone list)
@@ -418,18 +417,18 @@ program
         }
       }
       
-      console.log(chalk.bold(`\\nCompleted: ${chalk.green(successCount)} successful, ${chalk.red(failCount)} failed`));
+      console.log(chalk.bold(`\\n${i18n.t('status.completed', { success: chalk.green(successCount), failed: chalk.red(failCount) })}`));
       
     } catch (error) {
-      console.error(chalk.red(`Error: ${error.message}`));
+      console.error(chalk.red(i18n.t('error.general', { message: error.message })));
     }
   });
 
 program
   .command('preview [operation-id]')
-  .description('Preview what would be undone without making changes')
-  .option('-s, --session <id>', 'Specify session ID')
-  .option('--local', 'Use local ccundo tracking instead of Claude sessions')
+  .description(i18n.t('cmd.preview.description'))
+  .option('-s, --session <id>', i18n.t('opt.session'))
+  .option('--local', i18n.t('opt.local_tracking'))
   .action(async (operationId, options) => {
     try {
       let operations = [];
@@ -437,7 +436,7 @@ program
       if (options.local) {
         const sessionId = options.session || await SessionTracker.getCurrentSession();
         if (!sessionId) {
-          console.log(chalk.yellow('No local ccundo session found.'));
+          console.log(chalk.yellow(i18n.t('msg.no_local_session')));
           return;
         }
 
@@ -449,7 +448,7 @@ program
         const sessionFile = await parser.getCurrentSessionFile();
         
         if (!sessionFile) {
-          console.log(chalk.yellow('No active Claude Code session found in this directory.'));
+          console.log(chalk.yellow(i18n.t('msg.no_active_session')));
           return;
         }
         
@@ -457,7 +456,7 @@ program
       }
       
       if (operations.length === 0) {
-        console.log(chalk.yellow('No operations found.'));
+        console.log(chalk.yellow(i18n.t('msg.no_operations')));
         return;
       }
 
@@ -471,7 +470,7 @@ program
           let name = `${op.type} - ${formatDistance(op.timestamp)}`;
           
           if (operationsToUndo > 1) {
-            name += chalk.gray(` (+ ${operationsToUndo - 1} more would be undone)`);
+            name += chalk.gray(i18n.t('ui.more_would_be_undone', { count: operationsToUndo - 1 }));
           }
           
           return {
@@ -483,7 +482,7 @@ program
         const answer = await inquirer.prompt([{
           type: 'list',
           name: 'selectedIndex',
-          message: 'Select operation to preview:',
+          message: i18n.t('prompt.select_operation_preview'),
           choices: choices,
           pageSize: 15
         }]);
@@ -492,14 +491,14 @@ program
       } else {
         selectedIndex = operations.findIndex(op => op.id === operationId);
         if (selectedIndex === -1) {
-          console.log(chalk.red(`Operation ${operationId} not found.`));
+          console.log(chalk.red(i18n.t('error.operation_not_found', { id: operationId })));
           return;
         }
       }
       
       const operationsToUndo = operations.slice(0, selectedIndex + 1);
       
-      console.log(chalk.blue(`\\n📋 Preview: Would undo ${operationsToUndo.length} operation(s):\\n`));
+      console.log(chalk.blue(`\\n📋 ${i18n.t('ui.preview_undo', { count: operationsToUndo.length })}\\n`));
       
       for (let i = 0; i < operationsToUndo.length; i++) {
         const op = operationsToUndo[i];
@@ -510,17 +509,17 @@ program
         console.log('');
       }
       
-      console.log(chalk.gray('💡 To actually perform these undos, run: ccundo undo'));
+      console.log(chalk.gray(i18n.t('tip.perform_undos')));
       
     } catch (error) {
-      console.error(chalk.red(`Error: ${error.message}`));
+      console.error(chalk.red(i18n.t('error.general', { message: error.message })));
     }
   });
 
 program
   .command('sessions')
-  .description('List all available Claude Code sessions')
-  .option('--local', 'Show local ccundo sessions instead of Claude sessions')
+  .description(i18n.t('cmd.sessions.description'))
+  .option('--local', i18n.t('opt.show_local_sessions'))
   .action(async (options) => {
     try {
       if (options.local) {
@@ -528,11 +527,11 @@ program
         const currentSession = await SessionTracker.getCurrentSession();
         
         if (sessions.length === 0) {
-          console.log(chalk.yellow('No local sessions found.'));
+          console.log(chalk.yellow(i18n.t('msg.no_local_sessions')));
           return;
         }
         
-        console.log(chalk.bold('\nAvailable local sessions:\n'));
+        console.log(chalk.bold(`\n${i18n.t('header.available_sessions_local')}\n`));
         
         sessions.forEach(session => {
           const isCurrent = session === currentSession;
@@ -544,11 +543,11 @@ program
         const sessions = await parser.getAllSessions();
         
         if (sessions.length === 0) {
-          console.log(chalk.yellow('No Claude Code sessions found.'));
+          console.log(chalk.yellow(i18n.t('msg.no_sessions_found')));
           return;
         }
         
-        console.log(chalk.bold('\nAvailable Claude Code sessions:\n'));
+        console.log(chalk.bold(`\n${i18n.t('header.available_sessions_claude')}\n`));
         
         const currentProjectDir = await parser.getCurrentProjectDir();
         const currentProjectDirName = path.basename(currentProjectDir);
@@ -557,11 +556,11 @@ program
           const isCurrent = session.rawProjectDir === currentProjectDirName;
           const marker = isCurrent ? chalk.green('→ ') : '  ';
           console.log(`${marker}${chalk.cyan(session.id)}`);
-          console.log(`  Project: ${session.project}`);
+          console.log(`  ${i18n.t('label.project')}: ${session.project}`);
         });
       }
     } catch (error) {
-      console.error(chalk.red(`Error: ${error.message}`));
+      console.error(chalk.red(i18n.t('error.general', { message: error.message })));
     }
   });
 
@@ -571,9 +570,9 @@ program
   .action(async (sessionId) => {
     try {
       await SessionTracker.setCurrentSession(sessionId);
-      console.log(chalk.green(`Switched to session: ${sessionId}`));
+      console.log(chalk.green(i18n.t('msg.switched_to_session', { sessionId })));
     } catch (error) {
-      console.error(chalk.red(`Error: ${error.message}`));
+      console.error(chalk.red(i18n.t('error.general', { message: error.message })));
     }
   });
 
@@ -587,13 +586,13 @@ program
         const current = i18n.getCurrentLanguage();
         const available = i18n.getAvailableLanguages();
         
-        console.log(chalk.bold(`\\nCurrent language: ${chalk.cyan(current.name)} (${current.code})\\n`));
-        console.log(chalk.bold('Available languages:'));
+        console.log(chalk.bold(`\\n${i18n.t('ui.current_language', { name: chalk.cyan(current.name), code: current.code })}\\n`));
+        console.log(chalk.bold(i18n.t('ui.available_languages')));
         available.forEach(({ code, name }) => {
           const marker = code === current.code ? chalk.green('→ ') : '  ';
           console.log(`${marker}${code} - ${name}`);
         });
-        console.log(chalk.gray('\\nUsage: ccundo language <code>'));
+        console.log(chalk.gray(`\\n${i18n.t('ui.language_usage')}`));
         return;
       }
       

--- a/src/core/OperationPreview.js
+++ b/src/core/OperationPreview.js
@@ -21,7 +21,7 @@ export class OperationPreview {
       case OperationType.BASH_COMMAND:
         return await this.previewBashCommand(operation);
       default:
-        return { preview: `Unknown operation: ${operation.type}`, hasContent: false };
+        return { preview: i18n.t('error.unknown_operation', { type: operation.type }), hasContent: false };
     }
   }
 
@@ -32,7 +32,7 @@ export class OperationPreview {
       const exists = await fs.access(filePath).then(() => true).catch(() => false);
       if (!exists) {
         return {
-          preview: `${chalk.red('File does not exist:')} ${filePath}`,
+          preview: `${chalk.red(i18n.t('error.file_not_exist'))} ${filePath}`,
           hasContent: false
         };
       }
@@ -49,7 +49,7 @@ export class OperationPreview {
       };
     } catch (error) {
       return {
-        preview: `${chalk.red('Error reading file:')} ${filePath} - ${error.message}`,
+        preview: `${chalk.red(i18n.t('error.reading_file'))} ${filePath} - ${error.message}`,
         hasContent: false
       };
     }
@@ -87,11 +87,11 @@ export class OperationPreview {
         }
         
         if (maxLines > 10) {
-          preview += chalk.gray(`... (${maxLines - 10} more lines)`);
+          preview += chalk.gray(i18n.t('ui.more_lines', { count: maxLines - 10 }));
         }
       } else if (isMultiEdit && edits) {
         // Show what MultiEdit changes will be reversed
-        preview += chalk.gray('String replacements to be reversed:\n');
+        preview += chalk.gray(i18n.t('preview.string_replacements_reversed') + '\n');
         edits.forEach((edit, index) => {
           if (edit.new_string && edit.old_string !== undefined) {
             preview += `${index + 1}. "${chalk.red(edit.new_string)}" → "${chalk.green(edit.old_string)}"\n`;
@@ -99,10 +99,10 @@ export class OperationPreview {
         });
       } else if (oldString !== undefined && newString) {
         // Show what single edit will be reversed
-        preview += chalk.gray('String replacement to be reversed:\n');
+        preview += chalk.gray(i18n.t('preview.string_replacement_reversed') + '\n');
         preview += `"${chalk.red(newString)}" → "${chalk.green(oldString)}"`;
         if (replaceAll) {
-          preview += chalk.gray(' (all occurrences)');
+          preview += chalk.gray(i18n.t('preview.all_occurrences'));
         }
         preview += '\n\n';
         
@@ -117,7 +117,7 @@ export class OperationPreview {
         }
         
         if (foundLine >= 0) {
-          preview += chalk.gray('Context:\n');
+          preview += chalk.gray(i18n.t('preview.context') + '\n');
           const start = Math.max(0, foundLine - 2);
           const end = Math.min(lines.length, foundLine + 3);
           for (let i = start; i < end; i++) {
@@ -140,7 +140,7 @@ export class OperationPreview {
       };
     } catch (error) {
       return {
-        preview: `${chalk.yellow(i18n.t('action.will_revert_file'))} ${filePath}\n${chalk.red('Error:')} ${error.message}`,
+        preview: `${chalk.yellow(i18n.t('action.will_revert_file'))} ${filePath}\n${chalk.red(i18n.t('label.error'))} ${error.message}`,
         hasContent: false
       };
     }
@@ -182,7 +182,7 @@ export class OperationPreview {
     
     try {
       const exists = await fs.access(dirPath).then(() => true).catch(() => false);
-      const status = exists ? chalk.red('Will remove directory:') : chalk.gray('Directory already removed:');
+      const status = exists ? chalk.red(i18n.t('action.will_remove_directory')) : chalk.gray(i18n.t('status.directory_already_removed'));
       
       return {
         preview: `${status} ${dirPath}`,
@@ -191,7 +191,7 @@ export class OperationPreview {
       };
     } catch (error) {
       return {
-        preview: `${chalk.yellow('Will remove directory:')} ${dirPath}`,
+        preview: `${chalk.yellow(i18n.t('action.will_remove_directory'))} ${dirPath}`,
         hasContent: false,
         action: 'remove'
       };
@@ -202,7 +202,7 @@ export class OperationPreview {
     const { dirPath } = operation.data;
     
     return {
-      preview: `${chalk.green('Will restore directory:')} ${dirPath}`,
+      preview: `${chalk.green(i18n.t('action.will_restore_directory'))} ${dirPath}`,
       hasContent: false,
       action: 'restore'
     };

--- a/src/core/RedoManager.js
+++ b/src/core/RedoManager.js
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { OperationType } from './Operation.js';
+import { i18n } from '../i18n/i18n.js';
 
 export class RedoManager {
   constructor() {
@@ -29,7 +30,7 @@ export class RedoManager {
       case OperationType.BASH_COMMAND:
         return await this.redoBashCommand(operation);
       default:
-        throw new Error(`Unknown operation type: ${operation.type}`);
+        throw new Error(i18n.t('error.unknown_operation_type', { type: operation.type }));
     }
   }
 
@@ -42,7 +43,7 @@ export class RedoManager {
       if (exists) {
         return {
           success: false,
-          message: `Cannot redo file creation: ${filePath} already exists`
+          message: i18n.t('redo.cannot_redo_file_exists', { path: filePath })
         };
       }
 
@@ -57,7 +58,7 @@ export class RedoManager {
         if (!content) {
           return {
             success: false,
-            message: `Cannot redo file creation: no content available for ${filePath}`
+            message: i18n.t('redo.cannot_redo_no_content', { path: filePath })
           };
         }
       }
@@ -66,12 +67,12 @@ export class RedoManager {
       
       return {
         success: true,
-        message: `File recreated: ${filePath}`
+        message: i18n.t('redo.file_recreated', { path: filePath })
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to redo file creation: ${error.message}`
+        message: i18n.t('redo.failed_file_creation', { error: error.message })
       };
     }
   }
@@ -91,7 +92,7 @@ export class RedoManager {
         // because we don't know what the "new" content should be
         return {
           success: false,
-          message: `Cannot redo legacy file edit: insufficient data for ${filePath}`
+          message: i18n.t('redo.cannot_redo_legacy_edit', { path: filePath })
         };
       } else if (isMultiEdit && edits) {
         // Redo MultiEdit by applying each edit in original order
@@ -114,14 +115,14 @@ export class RedoManager {
           } else {
             return {
               success: false,
-              message: `Cannot redo edit: original string not found in ${filePath}`
+              message: i18n.t('redo.cannot_redo_edit', { path: filePath })
             };
           }
         }
       } else {
         return {
           success: false,
-          message: `Cannot redo file edit: insufficient data for ${filePath}`
+          message: i18n.t('redo.cannot_redo_edit_insufficient', { path: filePath })
         };
       }
       
@@ -129,13 +130,13 @@ export class RedoManager {
       
       return {
         success: true,
-        message: `File edit redone: ${filePath}`,
+        message: i18n.t('redo.file_edit_redone', { path: filePath }),
         backupPath
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to redo file edit: ${error.message}`
+        message: i18n.t('redo.failed_file_edit', { error: error.message })
       };
     }
   }
@@ -148,7 +149,7 @@ export class RedoManager {
       if (!exists) {
         return {
           success: false,
-          message: `Cannot redo file deletion: ${filePath} does not exist`
+          message: i18n.t('redo.cannot_redo_file_not_exist', { path: filePath })
         };
       }
 
@@ -161,13 +162,13 @@ export class RedoManager {
       
       return {
         success: true,
-        message: `File deleted again: ${filePath}`,
+        message: i18n.t('redo.file_deleted_again', { path: filePath }),
         backupPath
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to redo file deletion: ${error.message}`
+        message: i18n.t('redo.failed_file_deletion', { error: error.message })
       };
     }
   }
@@ -182,14 +183,14 @@ export class RedoManager {
       if (!oldExists) {
         return {
           success: false,
-          message: `Cannot redo rename: ${oldPath} does not exist`
+          message: i18n.t('redo.cannot_redo_rename_not_exist', { path: oldPath })
         };
       }
       
       if (newExists) {
         return {
           success: false,
-          message: `Cannot redo rename: ${newPath} already exists`
+          message: i18n.t('redo.cannot_redo_rename_exists', { path: newPath })
         };
       }
 
@@ -197,12 +198,12 @@ export class RedoManager {
       
       return {
         success: true,
-        message: `File renamed again: ${oldPath} → ${newPath}`
+        message: i18n.t('redo.file_renamed_again', { oldPath: oldPath, newPath: newPath })
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to redo rename: ${error.message}`
+        message: i18n.t('redo.failed_rename', { error: error.message })
       };
     }
   }
@@ -215,7 +216,7 @@ export class RedoManager {
       if (exists) {
         return {
           success: false,
-          message: `Cannot redo directory creation: ${dirPath} already exists`
+          message: i18n.t('redo.cannot_redo_dir_exists', { path: dirPath })
         };
       }
 
@@ -223,12 +224,12 @@ export class RedoManager {
       
       return {
         success: true,
-        message: `Directory created again: ${dirPath}`
+        message: i18n.t('redo.directory_created_again', { path: dirPath })
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to redo directory creation: ${error.message}`
+        message: i18n.t('redo.failed_directory_creation', { error: error.message })
       };
     }
   }
@@ -241,7 +242,7 @@ export class RedoManager {
       if (!exists) {
         return {
           success: false,
-          message: `Cannot redo directory deletion: ${dirPath} does not exist`
+          message: i18n.t('redo.cannot_redo_dir_not_exist', { path: dirPath })
         };
       }
 
@@ -249,12 +250,12 @@ export class RedoManager {
       
       return {
         success: true,
-        message: `Directory deleted again: ${dirPath}`
+        message: i18n.t('redo.directory_deleted_again', { path: dirPath })
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to redo directory deletion: ${error.message}`
+        message: i18n.t('redo.failed_directory_deletion', { error: error.message })
       };
     }
   }
@@ -264,7 +265,7 @@ export class RedoManager {
     
     return {
       success: false,
-      message: `Cannot redo bash command: ${command}\nPlease manually re-run the command.`
+      message: i18n.t('redo.cannot_redo_bash', { command: command })
     };
   }
 }

--- a/src/core/UndoManager.js
+++ b/src/core/UndoManager.js
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { OperationType } from './Operation.js';
+import { i18n } from '../i18n/i18n.js';
 
 export class UndoManager {
   constructor() {
@@ -29,7 +30,7 @@ export class UndoManager {
       case OperationType.BASH_COMMAND:
         return await this.undoBashCommand(operation);
       default:
-        throw new Error(`Unknown operation type: ${operation.type}`);
+        throw new Error(i18n.t('error.unknown_operation_type', { type: operation.type }));
     }
   }
 
@@ -44,13 +45,13 @@ export class UndoManager {
       
       return {
         success: true,
-        message: `File deleted: ${filePath}`,
+        message: i18n.t('undo.file_deleted', { path: filePath }),
         backupPath
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to undo file creation: ${error.message}`
+        message: i18n.t('undo.failed_file_creation', { error: error.message })
       };
     }
   }
@@ -91,14 +92,14 @@ export class UndoManager {
           } else {
             return {
               success: false,
-              message: `Cannot undo edit: expected string not found in ${filePath}`
+              message: i18n.t('undo.cannot_undo_edit', { path: filePath })
             };
           }
         }
       } else {
         return {
           success: false,
-          message: `Cannot undo file edit: insufficient data for ${filePath}`
+          message: i18n.t('undo.cannot_undo_edit_insufficient', { path: filePath })
         };
       }
       
@@ -106,13 +107,13 @@ export class UndoManager {
       
       return {
         success: true,
-        message: `File edit reverted: ${filePath}`,
+        message: i18n.t('undo.file_edit_reverted', { path: filePath }),
         backupPath
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to undo file edit: ${error.message}`
+        message: i18n.t('undo.failed_file_edit', { error: error.message })
       };
     }
   }
@@ -123,7 +124,7 @@ export class UndoManager {
     if (!content) {
       return {
         success: false,
-        message: `Cannot restore file: content not available for ${filePath}`
+        message: i18n.t('undo.cannot_restore_file', { path: filePath })
       };
     }
     
@@ -132,12 +133,12 @@ export class UndoManager {
       
       return {
         success: true,
-        message: `File restored: ${filePath}`
+        message: i18n.t('undo.file_restored', { path: filePath })
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to restore file: ${error.message}`
+        message: i18n.t('undo.failed_file_restore', { error: error.message })
       };
     }
   }
@@ -150,12 +151,12 @@ export class UndoManager {
       
       return {
         success: true,
-        message: `File renamed back: ${newPath} → ${oldPath}`
+        message: i18n.t('undo.file_renamed_back', { oldPath: newPath, newPath: oldPath })
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to undo rename: ${error.message}`
+        message: i18n.t('undo.failed_rename', { error: error.message })
       };
     }
   }
@@ -168,12 +169,12 @@ export class UndoManager {
       
       return {
         success: true,
-        message: `Directory removed: ${dirPath}`
+        message: i18n.t('undo.directory_removed', { path: dirPath })
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to remove directory: ${error.message}`
+        message: i18n.t('undo.failed_remove_directory', { error: error.message })
       };
     }
   }
@@ -186,12 +187,12 @@ export class UndoManager {
       
       return {
         success: true,
-        message: `Directory restored: ${dirPath}`
+        message: i18n.t('undo.directory_restored', { path: dirPath })
       };
     } catch (error) {
       return {
         success: false,
-        message: `Failed to restore directory: ${error.message}`
+        message: i18n.t('undo.failed_restore_directory', { error: error.message })
       };
     }
   }
@@ -201,7 +202,7 @@ export class UndoManager {
     
     return {
       success: false,
-      message: `Cannot auto-undo bash command: ${command}\nPlease manually revert any changes.`
+      message: i18n.t('undo.cannot_undo_bash', { command: command })
     };
   }
 }

--- a/src/hooks/claude-tracker.js
+++ b/src/hooks/claude-tracker.js
@@ -3,9 +3,13 @@
 import fs from 'fs/promises';
 import { SessionTracker } from '../core/SessionTracker.js';
 import { Operation, OperationType } from '../core/Operation.js';
+import { i18n } from '../i18n/i18n.js';
 
 async function trackOperation() {
   try {
+    // Initialize i18n
+    await i18n.init();
+    
     const input = JSON.parse(process.argv[2] || '{}');
     
     let sessionId = await SessionTracker.getCurrentSession();
@@ -85,7 +89,7 @@ async function trackOperation() {
       await tracker.addOperation(operation);
     }
   } catch (error) {
-    console.error('Failed to track operation:', error.message);
+    console.error(i18n.t('error.track_operation_failed'), error.message);
   }
 }
 

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -29,13 +29,13 @@ class I18n {
       const config = { language: this.currentLanguage };
       await fs.writeFile(this.configFile, JSON.stringify(config, null, 2));
     } catch (error) {
-      console.error('Failed to save language config:', error.message);
+      console.error(this.t('error.save_config_failed'), error.message);
     }
   }
 
   async setLanguage(lang) {
     if (!languages[lang]) {
-      throw new Error(`Unsupported language: ${lang}`);
+      throw new Error(this.t('error.unsupported_language', { language: lang }));
     }
     this.currentLanguage = lang;
     await this.saveConfig();
@@ -63,7 +63,7 @@ class I18n {
   getCurrentLanguage() {
     return {
       code: this.currentLanguage,
-      name: languages[this.currentLanguage]?.name || 'Unknown'
+      name: languages[this.currentLanguage]?.name || this.t('ui.unknown_language')
     };
   }
 }

--- a/src/i18n/languages.js
+++ b/src/i18n/languages.js
@@ -467,5 +467,193 @@ export const languages = {
       'suffix.more_would_be_undone': '(+ {count} weitere würden rückgängig gemacht)',
       'suffix.tip_to_undo': '💡 Um diese Rückgängigmachungen tatsächlich durchzuführen, führe aus: ccundo undo'
     }
+  },
+
+  zh: {
+    name: '简体中文',
+    messages: {
+      // Command descriptions
+      'cmd.list.description': '列出当前 Claude Code 会话中的所有操作',
+      'cmd.undo.description': '撤销当前 Claude Code 会话中的操作',
+      'cmd.redo.description': '重做之前撤销的操作',
+      'cmd.preview.description': '预览将要撤销的内容，但不进行更改',
+      'cmd.sessions.description': '列出所有可用的 Claude Code 会话',
+      'cmd.session.description': '切换到不同的会话',
+      'cmd.language.description': '设置界面语言',
+
+      // Options
+      'opt.all': '显示所有操作，包括已撤销的',
+      'opt.session': '指定会话 ID',
+      'opt.claude': '显示 Claude Code 会话的操作（默认）',
+      'opt.local': '显示本地 ccundo 跟踪的操作',
+      'opt.yes': '跳过确认',
+
+      // Messages
+      'msg.no_active_session': '在此目录中未找到活动的 Claude Code 会话。',
+      'msg.make_sure_directory': '请确保您在已使用 Claude Code 的目录中。',
+      'msg.no_local_session': '未找到本地 ccundo 会话。',
+      'msg.no_operations': '未找到操作。',
+      'msg.no_operations_to_undo': '没有可撤销的操作。',
+      'msg.no_operations_to_redo': '没有可重做的操作。',
+      'msg.operation_not_found': '未找到操作 {id}。',
+      'msg.already_undone': '此操作已被撤销。',
+      'msg.undo_cancelled': '撤销已取消。',
+      'msg.no_sessions_found': '未找到 Claude Code 会话。',
+      'msg.no_local_sessions': '未找到本地会话。',
+      'msg.language_set': '语言已设置为 {language}。',
+      'msg.language_invalid': '无效的语言。可用语言：{languages}',
+
+      // Prompts
+      'prompt.select_operation_undo': '选择要撤销的操作：',
+      'prompt.select_operation_redo': '选择要重做的操作：',
+      'prompt.select_operation_preview': '选择要预览的操作：',
+      'prompt.confirm_undo': '确定要撤销这 {count} 个操作吗？',
+      'prompt.confirm_redo': '确定要重做这 {count} 个操作吗？',
+      'prompt.cascading_warning': '⚠️ 级联撤销：选择一个操作将撤销该操作及其之后的所有操作。',
+
+      // Operation types
+      'op.file_create': '创建文件',
+      'op.file_edit': '编辑文件',
+      'op.file_delete': '删除文件',
+      'op.file_rename': '重命名文件',
+      'op.directory_create': '创建目录',
+      'op.directory_delete': '删除目录',
+      'op.bash_command': 'bash 命令',
+
+      // Operation actions
+      'action.will_delete_file': '将删除文件：',
+      'action.will_revert_file': '将还原文件：',
+      'action.will_restore_file': '将恢复文件：',
+      'action.will_rename_back': '将重命名回：',
+      'action.will_remove_directory': '将删除目录：',
+      'action.will_restore_directory': '将恢复目录：',
+      'action.cannot_undo_bash': '无法自动撤销 bash 命令：',
+      'action.manual_intervention': '需要手动干预',
+
+      // Headers
+      'header.operations_claude': 'Claude Code 会话的操作：',
+      'header.operations_local': '本地会话 {sessionId} 的操作：',
+      'header.available_sessions_claude': '可用的 Claude Code 会话：',
+      'header.available_sessions_local': '可用的本地会话：',
+      'header.preview': '📋 预览：将撤销 {count} 个操作：',
+      'header.undoing': '正在撤销 {count} 个操作...',
+      'header.redoing': '正在重做 {count} 个操作...',
+      'header.this_will_undo': '这将撤销 {count} 个操作：',
+      'header.this_will_redo': '这将重做 {count} 个操作：',
+
+      // Status
+      'status.active': '[活动]',
+      'status.undone': '[已撤销]',
+      'status.current_content': '当前内容：',
+      'status.content_to_restore': '要恢复的内容：',
+      'status.original_not_available': '（会话中原始内容不可用）',
+      'status.content_not_available': '（会话中内容不可用）',
+      'status.completed': '完成：{success} 个成功，{failed} 个失败',
+
+      // Time
+      'time.seconds_ago': '{seconds} 秒前',
+      'time.minutes_ago': '{minutes} 分钟前',
+      'time.hours_ago': '{hours} 小时前',
+      'time.days_ago': '{days} 天前',
+
+      // Suffixes
+      'suffix.more_operations': '（+ 还将撤销 {count} 个操作）',
+      'suffix.more_would_be_undone': '（+ 还将撤销 {count} 个操作）',
+      'suffix.tip_to_undo': '💡 要实际执行这些撤销，请运行：ccundo undo'
+    }
+  },
+
+  tw: {
+    name: '繁體中文',
+    messages: {
+      // Command descriptions
+      'cmd.list.description': '列出目前 Claude Code 會話中的所有操作',
+      'cmd.undo.description': '撤銷目前 Claude Code 會話中的操作',
+      'cmd.redo.description': '重做之前撤銷的操作',
+      'cmd.preview.description': '預覽將要撤銷的內容，但不進行更改',
+      'cmd.sessions.description': '列出所有可用的 Claude Code 會話',
+      'cmd.session.description': '切換到不同的會話',
+      'cmd.language.description': '設定介面語言',
+
+      // Options
+      'opt.all': '顯示所有操作，包括已撤銷的',
+      'opt.session': '指定會話 ID',
+      'opt.claude': '顯示 Claude Code 會話的操作（預設）',
+      'opt.local': '顯示本地 ccundo 跟踪的操作',
+      'opt.yes': '跳過確認',
+
+      // Messages
+      'msg.no_active_session': '在此目錄中未找到活動的 Claude Code 會話。',
+      'msg.make_sure_directory': '請確保您在使用過 Claude Code 的目錄中。',
+      'msg.no_local_session': '未找到本地 ccundo 會話。',
+      'msg.no_operations': '未找到操作。',
+      'msg.no_operations_to_undo': '沒有可撤銷的操作。',
+      'msg.no_operations_to_redo': '沒有可重做的操作。',
+      'msg.operation_not_found': '未找到操作 {id}。',
+      'msg.already_undone': '此操作已被撤銷。',
+      'msg.undo_cancelled': '撤銷已取消。',
+      'msg.no_sessions_found': '未找到 Claude Code 會話。',
+      'msg.no_local_sessions': '未找到本地會話。',
+      'msg.language_set': '語言已設定為 {language}。',
+      'msg.language_invalid': '無效的語言。可用語言：{languages}',
+
+      // Prompts
+      'prompt.select_operation_undo': '選擇要撤銷的操作：',
+      'prompt.select_operation_redo': '選擇要重做的操作：',
+      'prompt.select_operation_preview': '選擇要預覽的操作：',
+      'prompt.confirm_undo': '確定要撤銷這 {count} 個操作嗎？',
+      'prompt.confirm_redo': '確定要重做這 {count} 個操作嗎？',
+      'prompt.cascading_warning': '⚠️ 級聯撤銷：選擇一個操作將撤銷該操作及其之後的所有操作。',
+
+      // Operation types
+      'op.file_create': '創建文件',
+      'op.file_edit': '編輯文件',
+      'op.file_delete': '刪除文件',
+      'op.file_rename': '重命名文件',
+      'op.directory_create': '創建目錄',
+      'op.directory_delete': '刪除目錄',
+      'op.bash_command': 'bash 命令',
+
+      // Operation actions
+      'action.will_delete_file': '將刪除文件：',
+      'action.will_revert_file': '將還原文件：',
+      'action.will_restore_file': '將恢復文件：',
+      'action.will_rename_back': '將重命名回：',
+      'action.will_remove_directory': '將刪除目錄：',
+      'action.will_restore_directory': '將恢復目錄：',
+      'action.cannot_undo_bash': '無法自動撤銷 bash 命令：',
+      'action.manual_intervention': '需要手動干預',
+
+      // Headers
+      'header.operations_claude': 'Claude Code 會話的操作：',
+      'header.operations_local': '本地會話 {sessionId} 的操作：',
+      'header.available_sessions_claude': '可用的 Claude Code 會話：',
+      'header.available_sessions_local': '可用的本地會話：',
+      'header.preview': '📋 預覽：將撤銷 {count} 個操作：',
+      'header.undoing': '正在撤銷 {count} 個操作...',
+      'header.redoing': '正在重做 {count} 個操作...',
+      'header.this_will_undo': '這將撤銷 {count} 個操作：',
+      'header.this_will_redo': '這將重做 {count} 個操作：',
+
+      // Status
+      'status.active': '[活動]',
+      'status.undone': '[已撤銷]',
+      'status.current_content': '當前內容：',
+      'status.content_to_restore': '要恢復的內容：',
+      'status.original_not_available': '（會話中原始內容不可用）',
+      'status.content_not_available': '（會話中內容不可用）',
+      'status.completed': '完成：{success} 個成功，{failed} 個失敗',
+
+      // Time
+      'time.seconds_ago': '{seconds} 秒前',
+      'time.minutes_ago': '{minutes} 分鐘前',
+      'time.hours_ago': '{hours} 小時前',
+      'time.days_ago': '{days} 天前',
+
+      // Suffixes
+      'suffix.more_operations': '（+ 還將撤銷 {count} 個操作）',
+      'suffix.more_would_be_undone': '（+ 還將撤銷 {count} 個操作）',
+      'suffix.tip_to_undo': '💡 要實際執行這些撤銷，請運行：ccundo undo'
+    }
   }
 };

--- a/src/i18n/languages.js
+++ b/src/i18n/languages.js
@@ -2,6 +2,9 @@ export const languages = {
   en: {
     name: 'English',
     messages: {
+      // Program description
+      'program.description': 'Undo individual steps performed by Claude Code within a session',
+      
       // Command descriptions
       'cmd.list.description': 'List all operations in the current Claude Code session',
       'cmd.undo.description': 'Undo operations from the current Claude Code session',
@@ -17,6 +20,8 @@ export const languages = {
       'opt.claude': 'Show operations from Claude Code session (default)',
       'opt.local': 'Show operations from local ccundo tracking',
       'opt.yes': 'Skip confirmation',
+      'opt.local_tracking': 'Use local ccundo tracking instead of Claude sessions',
+      'opt.show_local_sessions': 'Show local ccundo sessions instead of Claude sessions',
       
       // Messages
       'msg.no_active_session': 'No active Claude Code session found in this directory.',
@@ -89,13 +94,122 @@ export const languages = {
       // Suffixes
       'suffix.more_operations': '(+ {count} more will be undone)',
       'suffix.more_would_be_undone': '(+ {count} more would be undone)',
-      'suffix.tip_to_undo': '💡 To actually perform these undos, run: ccundo undo'
+      'suffix.tip_to_undo': '💡 To actually perform these undos, run: ccundo undo',
+      
+      // Labels
+      'label.file': 'File',
+      'label.from': 'From',
+      'label.to': 'To',
+      'label.directory': 'Directory',
+      'label.command': 'Command',
+      'label.project': 'Project',
+      
+      // Error messages
+      'error.operation_not_found': 'Operation {id} not found.',
+      'error.save_config_failed': 'Failed to save language config:',
+      'error.track_operation_failed': 'Failed to track operation:',
+      'error.general': 'Error: {message}',
+      
+      // UI messages
+      'ui.undo_preview_header': 'This will undo {count} operation(s):',
+      'ui.undoing_operations': 'Undoing {count} operations...',
+      'ui.preview_undo': 'Preview: Would undo {count} operation(s):',
+      'ui.current_language': 'Current language: {name} ({code})',
+      'ui.available_languages': 'Available languages:',
+      'ui.language_usage': 'Usage: ccundo language <code>',
+      
+      // Additional messages
+      'msg.redo_not_implemented': 'Redo for local tracking is not yet implemented.',
+      'msg.redo_cancelled': 'Redo cancelled.',
+      'msg.switched_to_session': 'Switched to session: {sessionId}',
+      
+      // Tips
+      'tip.perform_undos': 'To actually perform these undos, run: ccundo undo',
+      
+      // Cascading warnings
+      'prompt.cascading_redo_warning': 'Cascading redo: Selecting an operation will redo it and ALL undone operations that came before it.',
+      
+      // Backup and file operations (New i18n keys)
+      'msg.backup_saved_to': 'Backup saved to: {path}',
+      
+      // Preview messages (New i18n keys)
+      'preview.string_replacements_reversed': 'String replacements to be reversed:',
+      'preview.string_replacement_reversed': 'String replacement to be reversed:',
+      'preview.all_occurrences': ' (all occurrences)',
+      'preview.context': 'Context:',
+      
+      // Additional error messages (New i18n keys)
+      'error.unknown_operation': 'Unknown operation: {type}',
+      'error.file_not_exist': 'File does not exist:',
+      'error.reading_file': 'Error reading file:',
+      'error.unknown_operation_type': 'Unknown operation type: {type}',
+      'error.unsupported_language': 'Unsupported language: {language}',
+      
+      // Additional status messages (New i18n keys)
+      'status.directory_already_removed': 'Directory already removed:',
+      
+      // UndoManager success messages (New i18n keys)
+      'undo.file_deleted': 'File deleted: {path}',
+      'undo.file_edit_reverted': 'File edit reverted: {path}',
+      'undo.file_restored': 'File restored: {path}',
+      'undo.file_renamed_back': 'File renamed back: {oldPath} → {newPath}',
+      'undo.directory_removed': 'Directory removed: {path}',
+      'undo.directory_restored': 'Directory restored: {path}',
+      
+      // UndoManager failure messages (New i18n keys)
+      'undo.failed_file_creation': 'Failed to undo file creation: {error}',
+      'undo.failed_file_edit': 'Failed to undo file edit: {error}',
+      'undo.failed_file_restore': 'Failed to restore file: {error}',
+      'undo.failed_rename': 'Failed to undo rename: {error}',
+      'undo.failed_remove_directory': 'Failed to remove directory: {error}',
+      'undo.failed_restore_directory': 'Failed to restore directory: {error}',
+      'undo.cannot_undo_edit': 'Cannot undo edit: expected string not found in {path}',
+      'undo.cannot_undo_edit_insufficient': 'Cannot undo file edit: insufficient data for {path}',
+      'undo.cannot_restore_file': 'Cannot restore file: content not available for {path}',
+      'undo.cannot_undo_bash': 'Cannot auto-undo bash command: {command}\nPlease manually revert any changes.',
+      
+      // RedoManager success messages (New i18n keys)
+      'redo.file_recreated': 'File recreated: {path}',
+      'redo.file_edit_redone': 'File edit redone: {path}',
+      'redo.file_deleted_again': 'File deleted again: {path}',
+      'redo.file_renamed_again': 'File renamed again: {oldPath} → {newPath}',
+      'redo.directory_created_again': 'Directory created again: {path}',
+      'redo.directory_deleted_again': 'Directory deleted again: {path}',
+      
+      // RedoManager failure messages (New i18n keys)
+      'redo.cannot_redo_file_exists': 'Cannot redo file creation: {path} already exists',
+      'redo.cannot_redo_no_content': 'Cannot redo file creation: no content available for {path}',
+      'redo.failed_file_creation': 'Failed to redo file creation: {error}',
+      'redo.cannot_redo_legacy_edit': 'Cannot redo legacy file edit: insufficient data for {path}',
+      'redo.cannot_redo_edit': 'Cannot redo edit: original string not found in {path}',
+      'redo.cannot_redo_edit_insufficient': 'Cannot redo file edit: insufficient data for {path}',
+      'redo.failed_file_edit': 'Failed to redo file edit: {error}',
+      'redo.cannot_redo_file_not_exist': 'Cannot redo file deletion: {path} does not exist',
+      'redo.failed_file_deletion': 'Failed to redo file deletion: {error}',
+      'redo.cannot_redo_rename_not_exist': 'Cannot redo rename: {path} does not exist',
+      'redo.cannot_redo_rename_exists': 'Cannot redo rename: {path} already exists',
+      'redo.failed_rename': 'Failed to redo rename: {error}',
+      'redo.cannot_redo_dir_exists': 'Cannot redo directory creation: {path} already exists',
+      'redo.failed_directory_creation': 'Failed to redo directory creation: {error}',
+      'redo.cannot_redo_dir_not_exist': 'Cannot redo directory deletion: {path} does not exist',
+      'redo.failed_directory_deletion': 'Failed to redo directory deletion: {error}',
+      'redo.cannot_redo_bash': 'Cannot redo bash command: {command}\nPlease manually re-run the command.',
+      
+      // Additional UI messages (New i18n keys)
+      'ui.more_will_be_undone': ' (+ {count} more will be undone)',
+      'ui.more_will_be_redone': ' (+ {count} more will be redone)',
+      'ui.more_would_be_undone': ' (+ {count} more would be undone)',
+      'ui.more_lines': '... ({count} more lines)',
+      'ui.unknown_language': 'Unknown'
     }
   },
   
   ja: {
     name: '日本語',
     messages: {
+      // Program description
+      'program.description': 'Claude Codeセッション内で実行された個別のステップを元に戻す',
+      
       // Command descriptions
       'cmd.list.description': '現在のClaude Codeセッションのすべての操作を一覧表示',
       'cmd.undo.description': '現在のClaude Codeセッションの操作を元に戻す',
@@ -111,6 +225,8 @@ export const languages = {
       'opt.claude': 'Claude Codeセッションの操作を表示（デフォルト）',
       'opt.local': 'ローカルccundo追跡の操作を表示',
       'opt.yes': '確認をスキップ',
+      'opt.local_tracking': 'Claudeセッションの代わりにローカルccundo追跡を使用',
+      'opt.show_local_sessions': 'Claudeセッションの代わりにローカルccundoセッションを表示',
       
       // Messages
       'msg.no_active_session': 'このディレクトリでアクティブなClaude Codeセッションが見つかりません。',
@@ -183,13 +299,122 @@ export const languages = {
       // Suffixes
       'suffix.more_operations': '（+ {count}個も元に戻されます）',
       'suffix.more_would_be_undone': '（+ {count}個も元に戻されます）',
-      'suffix.tip_to_undo': '💡 実際に元に戻すには次を実行: ccundo undo'
+      'suffix.tip_to_undo': '💡 実際に元に戻すには次を実行: ccundo undo',
+      
+      // Labels
+      'label.file': 'ファイル',
+      'label.from': '元',
+      'label.to': '先',
+      'label.directory': 'ディレクトリ',
+      'label.command': 'コマンド',
+      'label.project': 'プロジェクト',
+      
+      // Error messages
+      'error.operation_not_found': '操作 {id} が見つかりません。',
+      'error.save_config_failed': '言語設定の保存に失敗しました：',
+      'error.track_operation_failed': '操作の追跡に失敗しました：',
+      'error.general': 'エラー：{message}',
+      
+      // UI messages
+      'ui.undo_preview_header': 'これにより{count}個の操作が元に戻されます：',
+      'ui.undoing_operations': '{count}個の操作を元に戻しています...',
+      'ui.preview_undo': 'プレビュー：{count}個の操作を元に戻します：',
+      'ui.current_language': '現在の言語：{name} ({code})',
+      'ui.available_languages': '利用可能な言語：',
+      'ui.language_usage': '使用方法：ccundo language <code>',
+      
+      // Additional messages
+      'msg.redo_not_implemented': 'ローカル追跡のやり直しはまだ実装されていません。',
+      'msg.redo_cancelled': 'やり直しがキャンセルされました。',
+      'msg.switched_to_session': 'セッションを切り替えました：{sessionId}',
+      
+      // Tips
+      'tip.perform_undos': '実際に元に戻すには次を実行：ccundo undo',
+      
+      // Cascading warnings
+      'prompt.cascading_redo_warning': 'カスケードやり直し：操作を選択すると、その操作とその前のすべての取り消された操作がやり直されます。',
+      
+      // Backup and file operations (New i18n keys)
+      'msg.backup_saved_to': 'バックアップを保存しました：{path}',
+      
+      // Preview messages (New i18n keys)
+      'preview.string_replacements_reversed': '元に戻される文字列置換：',
+      'preview.string_replacement_reversed': '元に戻される文字列置換：',
+      'preview.all_occurrences': '（すべての出現箇所）',
+      'preview.context': 'コンテキスト：',
+      
+      // Additional error messages (New i18n keys)
+      'error.unknown_operation': '不明な操作：{type}',
+      'error.file_not_exist': 'ファイルが存在しません：',
+      'error.reading_file': 'ファイル読み込みエラー：',
+      'error.unknown_operation_type': '不明な操作タイプ：{type}',
+      'error.unsupported_language': 'サポートされていない言語：{language}',
+      
+      // Additional status messages (New i18n keys)
+      'status.directory_already_removed': 'ディレクトリは既に削除済み：',
+      
+      // UndoManager success messages (New i18n keys)
+      'undo.file_deleted': 'ファイルを削除しました：{path}',
+      'undo.file_edit_reverted': 'ファイル編集を元に戻しました：{path}',
+      'undo.file_restored': 'ファイルを復元しました：{path}',
+      'undo.file_renamed_back': 'ファイル名を元に戻しました：{oldPath} → {newPath}',
+      'undo.directory_removed': 'ディレクトリを削除しました：{path}',
+      'undo.directory_restored': 'ディレクトリを復元しました：{path}',
+      
+      // UndoManager failure messages (New i18n keys)
+      'undo.failed_file_creation': 'ファイル作成の取り消しに失敗しました：{error}',
+      'undo.failed_file_edit': 'ファイル編集の取り消しに失敗しました：{error}',
+      'undo.failed_file_restore': 'ファイルの復元に失敗しました：{error}',
+      'undo.failed_rename': '名前変更の取り消しに失敗しました：{error}',
+      'undo.failed_remove_directory': 'ディレクトリの削除に失敗しました：{error}',
+      'undo.failed_restore_directory': 'ディレクトリの復元に失敗しました：{error}',
+      'undo.cannot_undo_edit': '編集を取り消せません：{path}で期待される文字列が見つかりません',
+      'undo.cannot_undo_edit_insufficient': 'ファイル編集を取り消せません：{path}のデータが不十分です',
+      'undo.cannot_restore_file': 'ファイルを復元できません：{path}のコンテンツが利用できません',
+      'undo.cannot_undo_bash': 'bashコマンドを自動で取り消せません：{command}\n手動で変更を元に戻してください。',
+
+      // RedoManager success messages (New i18n keys)
+      'redo.file_recreated': 'ファイルを再作成しました：{path}',
+      'redo.file_edit_redone': 'ファイル編集をやり直しました：{path}',
+      'redo.file_deleted_again': 'ファイルを再び削除しました：{path}',
+      'redo.file_renamed_again': 'ファイルを再び名前変更しました：{oldPath} → {newPath}',
+      'redo.directory_created_again': 'ディレクトリを再び作成しました：{path}',
+      'redo.directory_deleted_again': 'ディレクトリを再び削除しました：{path}',
+
+      // RedoManager failure messages (New i18n keys)
+      'redo.cannot_redo_file_exists': 'ファイル作成をやり直せません：{path}は既に存在します',
+      'redo.cannot_redo_no_content': 'ファイル作成をやり直せません：{path}のコンテンツが利用できません',
+      'redo.failed_file_creation': 'ファイル作成のやり直しに失敗しました：{error}',
+      'redo.cannot_redo_legacy_edit': 'レガシーファイル編集をやり直せません：{path}のデータが不十分です',
+      'redo.cannot_redo_edit': '編集をやり直せません：{path}で元の文字列が見つかりません',
+      'redo.cannot_redo_edit_insufficient': 'ファイル編集をやり直せません：{path}のデータが不十分です',
+      'redo.failed_file_edit': 'ファイル編集のやり直しに失敗しました：{error}',
+      'redo.cannot_redo_file_not_exist': 'ファイル削除をやり直せません：{path}が存在しません',
+      'redo.failed_file_deletion': 'ファイル削除のやり直しに失敗しました：{error}',
+      'redo.cannot_redo_rename_not_exist': '名前変更をやり直せません：{path}が存在しません',
+      'redo.cannot_redo_rename_exists': '名前変更をやり直せません：{path}が既に存在します',
+      'redo.failed_rename': '名前変更のやり直しに失敗しました：{error}',
+      'redo.cannot_redo_dir_exists': 'ディレクトリ作成をやり直せません：{path}が既に存在します',
+      'redo.failed_directory_creation': 'ディレクトリ作成のやり直しに失敗しました：{error}',
+      'redo.cannot_redo_dir_not_exist': 'ディレクトリ削除をやり直せません：{path}が存在しません',
+      'redo.failed_directory_deletion': 'ディレクトリ削除のやり直しに失敗しました：{error}',
+      'redo.cannot_redo_bash': 'bashコマンドをやり直せません：{command}\n手動でコマンドを再実行してください。',
+
+      // Additional UI messages (New i18n keys)
+      'ui.more_will_be_undone': '（+ {count}個も元に戻されます）',
+      'ui.more_will_be_redone': '（+ {count}個もやり直されます）',
+      'ui.more_would_be_undone': '（+ {count}個も元に戻されます）',
+      'ui.more_lines': '... （{count}行続く）',
+      'ui.unknown_language': '不明'
     }
   },
 
   fr: {
     name: 'Français',
     messages: {
+      // Program description
+      'program.description': 'Annuler les étapes individuelles effectuées par Claude Code dans une session',
+      
       // Command descriptions
       'cmd.list.description': 'Lister toutes les opérations de la session Claude Code actuelle',
       'cmd.undo.description': 'Annuler les opérations de la session Claude Code actuelle',
@@ -205,6 +430,8 @@ export const languages = {
       'opt.claude': 'Afficher les opérations de la session Claude Code (par défaut)',
       'opt.local': 'Afficher les opérations du suivi local ccundo',
       'opt.yes': 'Ignorer la confirmation',
+      'opt.local_tracking': 'Utiliser le suivi local ccundo au lieu des sessions Claude',
+      'opt.show_local_sessions': 'Afficher les sessions locales ccundo au lieu des sessions Claude',
 
       // Messages
       'msg.no_active_session': 'Aucune session Claude Code active trouvée dans ce répertoire.',
@@ -277,13 +504,122 @@ export const languages = {
       // Suffixes
       'suffix.more_operations': '(+ {count} de plus seront annulées)',
       'suffix.more_would_be_undone': '(+ {count} de plus seraient annulées)',
-      'suffix.tip_to_undo': '💡 Pour effectuer réellement ces annulations, exécutez : ccundo undo'
+      'suffix.tip_to_undo': '💡 Pour effectuer réellement ces annulations, exécutez : ccundo undo',
+      
+      // Labels
+      'label.file': 'Fichier',
+      'label.from': 'De',
+      'label.to': 'Vers',
+      'label.directory': 'Répertoire',
+      'label.command': 'Commande',
+      'label.project': 'Projet',
+      
+      // Error messages
+      'error.operation_not_found': 'Opération {id} introuvable.',
+      'error.save_config_failed': 'Échec de sauvegarde de la configuration linguistique :',
+      'error.track_operation_failed': 'Échec du suivi de l\'opération :',
+      'error.general': 'Erreur : {message}',
+      
+      // UI messages
+      'ui.undo_preview_header': 'Ceci annulera {count} opération(s) :',
+      'ui.undoing_operations': 'Annulation de {count} opérations...',
+      'ui.preview_undo': 'Prévisualisation : Annulerait {count} opération(s) :',
+      'ui.current_language': 'Langue actuelle : {name} ({code})',
+      'ui.available_languages': 'Langues disponibles :',
+      'ui.language_usage': 'Usage : ccundo language <code>',
+      
+      // Additional messages
+      'msg.redo_not_implemented': 'Le rétablissement pour le suivi local n\'est pas encore implémenté.',
+      'msg.redo_cancelled': 'Rétablissement annulé.',
+      'msg.switched_to_session': 'Basculé vers la session : {sessionId}',
+      
+      // Tips
+      'tip.perform_undos': 'Pour effectuer réellement ces annulations, exécutez : ccundo undo',
+      
+      // Cascading warnings
+      'prompt.cascading_redo_warning': 'Rétablissement en cascade : Sélectionner une opération la rétablira ainsi que TOUTES les opérations annulées qui l\'ont précédée.',
+      
+      // Backup and file operations (New i18n keys)
+      'msg.backup_saved_to': 'Sauvegarde enregistrée dans : {path}',
+      
+      // Preview messages (New i18n keys)
+      'preview.string_replacements_reversed': 'Remplacements de chaînes à annuler :',
+      'preview.string_replacement_reversed': 'Remplacement de chaîne à annuler :',
+      'preview.all_occurrences': ' (toutes les occurrences)',
+      'preview.context': 'Contexte :',
+      
+      // Additional error messages (New i18n keys)
+      'error.unknown_operation': 'Opération inconnue : {type}',
+      'error.file_not_exist': 'Le fichier n\'existe pas :',
+      'error.reading_file': 'Erreur de lecture du fichier :',
+      'error.unknown_operation_type': 'Type d\'opération inconnu : {type}',
+      'error.unsupported_language': 'Langue non supportée : {language}',
+      
+      // Additional status messages (New i18n keys)
+      'status.directory_already_removed': 'Répertoire déjà supprimé :',
+      
+      // UndoManager success messages (New i18n keys)
+      'undo.file_deleted': 'Fichier supprimé : {path}',
+      'undo.file_edit_reverted': 'Modification de fichier annulée : {path}',
+      'undo.file_restored': 'Fichier restauré : {path}',
+      'undo.file_renamed_back': 'Fichier renommé en arrière : {oldPath} → {newPath}',
+      'undo.directory_removed': 'Répertoire supprimé : {path}',
+      'undo.directory_restored': 'Répertoire restauré : {path}',
+      
+      // UndoManager failure messages (New i18n keys)
+      'undo.failed_file_creation': 'Échec de l\'annulation de la création de fichier : {error}',
+      'undo.failed_file_edit': 'Échec de l\'annulation de la modification de fichier : {error}',
+      'undo.failed_file_restore': 'Échec de la restauration de fichier : {error}',
+      'undo.failed_rename': 'Échec de l\'annulation du renommage : {error}',
+      'undo.failed_remove_directory': 'Échec de la suppression de répertoire : {error}',
+      'undo.failed_restore_directory': 'Échec de la restauration de répertoire : {error}',
+      'undo.cannot_undo_edit': 'Impossible d\'annuler la modification : chaîne attendue non trouvée dans {path}',
+      'undo.cannot_undo_edit_insufficient': 'Impossible d\'annuler la modification de fichier : données insuffisantes pour {path}',
+      'undo.cannot_restore_file': 'Impossible de restaurer le fichier : contenu non disponible pour {path}',
+      'undo.cannot_undo_bash': 'Impossible d\'annuler automatiquement la commande bash : {command}\nVeuillez annuler manuellement les modifications.',
+
+      // RedoManager success messages (New i18n keys)
+      'redo.file_recreated': 'Fichier recréé : {path}',
+      'redo.file_edit_redone': 'Modification de fichier rétablie : {path}',
+      'redo.file_deleted_again': 'Fichier supprimé à nouveau : {path}',
+      'redo.file_renamed_again': 'Fichier renommé à nouveau : {oldPath} → {newPath}',
+      'redo.directory_created_again': 'Répertoire créé à nouveau : {path}',
+      'redo.directory_deleted_again': 'Répertoire supprimé à nouveau : {path}',
+
+      // RedoManager failure messages (New i18n keys)
+      'redo.cannot_redo_file_exists': 'Impossible de rétablir la création de fichier : {path} existe déjà',
+      'redo.cannot_redo_no_content': 'Impossible de rétablir la création de fichier : aucun contenu disponible pour {path}',
+      'redo.failed_file_creation': 'Échec du rétablissement de la création de fichier : {error}',
+      'redo.cannot_redo_legacy_edit': 'Impossible de rétablir la modification de fichier héritée : données insuffisantes pour {path}',
+      'redo.cannot_redo_edit': 'Impossible de rétablir la modification : chaîne originale non trouvée dans {path}',
+      'redo.cannot_redo_edit_insufficient': 'Impossible de rétablir la modification de fichier : données insuffisantes pour {path}',
+      'redo.failed_file_edit': 'Échec du rétablissement de la modification de fichier : {error}',
+      'redo.cannot_redo_file_not_exist': 'Impossible de rétablir la suppression de fichier : {path} n\'existe pas',
+      'redo.failed_file_deletion': 'Échec du rétablissement de la suppression de fichier : {error}',
+      'redo.cannot_redo_rename_not_exist': 'Impossible de rétablir le renommage : {path} n\'existe pas',
+      'redo.cannot_redo_rename_exists': 'Impossible de rétablir le renommage : {path} existe déjà',
+      'redo.failed_rename': 'Échec du rétablissement du renommage : {error}',
+      'redo.cannot_redo_dir_exists': 'Impossible de rétablir la création de répertoire : {path} existe déjà',
+      'redo.failed_directory_creation': 'Échec du rétablissement de la création de répertoire : {error}',
+      'redo.cannot_redo_dir_not_exist': 'Impossible de rétablir la suppression de répertoire : {path} n\'existe pas',
+      'redo.failed_directory_deletion': 'Échec du rétablissement de la suppression de répertoire : {error}',
+      'redo.cannot_redo_bash': 'Impossible de rétablir la commande bash : {command}\nVeuillez réexécuter la commande manuellement.',
+
+      // Additional UI messages (New i18n keys)
+      'ui.more_will_be_undone': ' (+ {count} de plus seront annulées)',
+      'ui.more_will_be_redone': ' (+ {count} de plus seront rétablies)',
+      'ui.more_would_be_undone': ' (+ {count} de plus seraient annulées)',
+      'ui.more_lines': '... ({count} lignes supplémentaires)',
+      'ui.unknown_language': 'Inconnu'
     }
   },
 
   es: {
     name: 'Español',
     messages: {
+      // Program description
+      'program.description': 'Deshacer pasos individuales realizados por Claude Code dentro de una sesión',
+      
       // Command descriptions
       'cmd.list.description': 'Listar todas las operaciones en la sesión actual de Claude Code',
       'cmd.undo.description': 'Deshacer operaciones de la sesión actual de Claude Code',
@@ -299,6 +635,8 @@ export const languages = {
       'opt.claude': 'Mostrar operaciones de la sesión de Claude Code (predeterminado)',
       'opt.local': 'Mostrar operaciones del seguimiento local de ccundo',
       'opt.yes': 'Omitir confirmación',
+      'opt.local_tracking': 'Usar seguimiento local ccundo en lugar de sesiones Claude',
+      'opt.show_local_sessions': 'Mostrar sesiones locales ccundo en lugar de sesiones Claude',
 
       // Messages
       'msg.no_active_session': 'No se encontró ninguna sesión activa de Claude Code en este directorio.',
@@ -371,13 +709,122 @@ export const languages = {
       // Suffixes
       'suffix.more_operations': '(+ {count} más serán deshechas)',
       'suffix.more_would_be_undone': '(+ {count} más serían deshechas)',
-      'suffix.tip_to_undo': '💡 Para realizar realmente estos deshacer, ejecuta: ccundo undo'
+      'suffix.tip_to_undo': '💡 Para realizar realmente estos deshacer, ejecuta: ccundo undo',
+      
+      // Labels
+      'label.file': 'Archivo',
+      'label.from': 'De',
+      'label.to': 'A',
+      'label.directory': 'Directorio',
+      'label.command': 'Comando',
+      'label.project': 'Proyecto',
+      
+      // Error messages
+      'error.operation_not_found': 'Operación {id} no encontrada.',
+      'error.save_config_failed': 'Error al guardar la configuración de idioma:',
+      'error.track_operation_failed': 'Error al rastrear la operación:',
+      'error.general': 'Error: {message}',
+      
+      // UI messages
+      'ui.undo_preview_header': 'Esto deshará {count} operación(es):',
+      'ui.undoing_operations': 'Deshaciendo {count} operaciones...',
+      'ui.preview_undo': 'Previsualización: Desharía {count} operación(es):',
+      'ui.current_language': 'Idioma actual: {name} ({code})',
+      'ui.available_languages': 'Idiomas disponibles:',
+      'ui.language_usage': 'Uso: ccundo language <code>',
+      
+      // Additional messages
+      'msg.redo_not_implemented': 'Rehacer para seguimiento local aún no está implementado.',
+      'msg.redo_cancelled': 'Rehacer cancelado.',
+      'msg.switched_to_session': 'Cambiado a la sesión: {sessionId}',
+      
+      // Tips
+      'tip.perform_undos': 'Para realizar realmente estos deshacer, ejecuta: ccundo undo',
+      
+      // Cascading warnings
+      'prompt.cascading_redo_warning': 'Rehacer en cascada: Seleccionar una operación la rehará y TODAS las operaciones deshacidas que vinieron antes.',
+      
+      // Backup and file operations (New i18n keys)
+      'msg.backup_saved_to': 'Copia de seguridad guardada en: {path}',
+      
+      // Preview messages (New i18n keys)
+      'preview.string_replacements_reversed': 'Reemplazos de cadena a revertir:',
+      'preview.string_replacement_reversed': 'Reemplazo de cadena a revertir:',
+      'preview.all_occurrences': ' (todas las ocurrencias)',
+      'preview.context': 'Contexto:',
+      
+      // Additional error messages (New i18n keys)
+      'error.unknown_operation': 'Operación desconocida: {type}',
+      'error.file_not_exist': 'El archivo no existe:',
+      'error.reading_file': 'Error leyendo archivo:',
+      'error.unknown_operation_type': 'Tipo de operación desconocido: {type}',
+      'error.unsupported_language': 'Idioma no soportado: {language}',
+      
+      // Additional status messages (New i18n keys)
+      'status.directory_already_removed': 'Directorio ya eliminado:',
+      
+      // UndoManager success messages (New i18n keys)
+      'undo.file_deleted': 'Archivo eliminado: {path}',
+      'undo.file_edit_reverted': 'Edición de archivo revertida: {path}',
+      'undo.file_restored': 'Archivo restaurado: {path}',
+      'undo.file_renamed_back': 'Archivo renombrado de vuelta: {oldPath} → {newPath}',
+      'undo.directory_removed': 'Directorio eliminado: {path}',
+      'undo.directory_restored': 'Directorio restaurado: {path}',
+      
+      // UndoManager failure messages (New i18n keys)
+      'undo.failed_file_creation': 'Error al deshacer creación de archivo: {error}',
+      'undo.failed_file_edit': 'Error al deshacer edición de archivo: {error}',
+      'undo.failed_file_restore': 'Error al restaurar archivo: {error}',
+      'undo.failed_rename': 'Error al deshacer renombrado: {error}',
+      'undo.failed_remove_directory': 'Error al eliminar directorio: {error}',
+      'undo.failed_restore_directory': 'Error al restaurar directorio: {error}',
+      'undo.cannot_undo_edit': 'No se puede deshacer edición: cadena esperada no encontrada en {path}',
+      'undo.cannot_undo_edit_insufficient': 'No se puede deshacer edición de archivo: datos insuficientes para {path}',
+      'undo.cannot_restore_file': 'No se puede restaurar archivo: contenido no disponible para {path}',
+      'undo.cannot_undo_bash': 'No se puede deshacer automáticamente comando bash: {command}\nPor favor revierta los cambios manualmente.',
+
+      // RedoManager success messages (New i18n keys)
+      'redo.file_recreated': 'Archivo recreado: {path}',
+      'redo.file_edit_redone': 'Edición de archivo rehecha: {path}',
+      'redo.file_deleted_again': 'Archivo eliminado de nuevo: {path}',
+      'redo.file_renamed_again': 'Archivo renombrado de nuevo: {oldPath} → {newPath}',
+      'redo.directory_created_again': 'Directorio creado de nuevo: {path}',
+      'redo.directory_deleted_again': 'Directorio eliminado de nuevo: {path}',
+
+      // RedoManager failure messages (New i18n keys)
+      'redo.cannot_redo_file_exists': 'No se puede rehacer creación de archivo: {path} ya existe',
+      'redo.cannot_redo_no_content': 'No se puede rehacer creación de archivo: sin contenido disponible para {path}',
+      'redo.failed_file_creation': 'Error al rehacer creación de archivo: {error}',
+      'redo.cannot_redo_legacy_edit': 'No se puede rehacer edición de archivo heredado: datos insuficientes para {path}',
+      'redo.cannot_redo_edit': 'No se puede rehacer edición: cadena original no encontrada en {path}',
+      'redo.cannot_redo_edit_insufficient': 'No se puede rehacer edición de archivo: datos insuficientes para {path}',
+      'redo.failed_file_edit': 'Error al rehacer edición de archivo: {error}',
+      'redo.cannot_redo_file_not_exist': 'No se puede rehacer eliminación de archivo: {path} no existe',
+      'redo.failed_file_deletion': 'Error al rehacer eliminación de archivo: {error}',
+      'redo.cannot_redo_rename_not_exist': 'No se puede rehacer renombrado: {path} no existe',
+      'redo.cannot_redo_rename_exists': 'No se puede rehacer renombrado: {path} ya existe',
+      'redo.failed_rename': 'Error al rehacer renombrado: {error}',
+      'redo.cannot_redo_dir_exists': 'No se puede rehacer creación de directorio: {path} ya existe',
+      'redo.failed_directory_creation': 'Error al rehacer creación de directorio: {error}',
+      'redo.cannot_redo_dir_not_exist': 'No se puede rehacer eliminación de directorio: {path} no existe',
+      'redo.failed_directory_deletion': 'Error al rehacer eliminación de directorio: {error}',
+      'redo.cannot_redo_bash': 'No se puede rehacer comando bash: {command}\nPor favor vuelva a ejecutar el comando manualmente.',
+
+      // Additional UI messages (New i18n keys)
+      'ui.more_will_be_undone': ' (+ {count} más serán deshachas)',
+      'ui.more_will_be_redone': ' (+ {count} más serán rehechas)',
+      'ui.more_would_be_undone': ' (+ {count} más serían deshachas)',
+      'ui.more_lines': '... ({count} líneas más)',
+      'ui.unknown_language': 'Desconocido'
     }
   },
 
   de: {
     name: 'Deutsch',
     messages: {
+      // Program description
+      'program.description': 'Individuelle Schritte rückgängig machen, die von Claude Code in einer Sitzung ausgeführt wurden',
+      
       // Command descriptions
       'cmd.list.description': 'Alle Operationen in der aktuellen Claude Code Sitzung auflisten',
       'cmd.undo.description': 'Operationen aus der aktuellen Claude Code Sitzung rückgängig machen',
@@ -393,6 +840,8 @@ export const languages = {
       'opt.claude': 'Operationen aus der Claude Code Sitzung anzeigen (Standard)',
       'opt.local': 'Operationen aus der lokalen ccundo Verfolgung anzeigen',
       'opt.yes': 'Bestätigung überspringen',
+      'opt.local_tracking': 'Lokale ccundo Verfolgung anstelle von Claude Sitzungen verwenden',
+      'opt.show_local_sessions': 'Lokale ccundo Sitzungen anstelle von Claude Sitzungen anzeigen',
 
       // Messages
       'msg.no_active_session': 'Keine aktive Claude Code Sitzung in diesem Verzeichnis gefunden.',
@@ -465,13 +914,122 @@ export const languages = {
       // Suffixes
       'suffix.more_operations': '(+ {count} weitere werden rückgängig gemacht)',
       'suffix.more_would_be_undone': '(+ {count} weitere würden rückgängig gemacht)',
-      'suffix.tip_to_undo': '💡 Um diese Rückgängigmachungen tatsächlich durchzuführen, führe aus: ccundo undo'
+      'suffix.tip_to_undo': '💡 Um diese Rückgängigmachungen tatsächlich durchzuführen, führe aus: ccundo undo',
+      
+      // Labels
+      'label.file': 'Datei',
+      'label.from': 'Von',
+      'label.to': 'Nach',
+      'label.directory': 'Verzeichnis',
+      'label.command': 'Befehl',
+      'label.project': 'Projekt',
+      
+      // Error messages
+      'error.operation_not_found': 'Operation {id} nicht gefunden.',
+      'error.save_config_failed': 'Fehler beim Speichern der Sprachkonfiguration:',
+      'error.track_operation_failed': 'Fehler beim Verfolgen der Operation:',
+      'error.general': 'Fehler: {message}',
+      
+      // UI messages
+      'ui.undo_preview_header': 'Dies wird {count} Operation(en) rückgängig machen:',
+      'ui.undoing_operations': 'Mache {count} Operationen rückgängig...',
+      'ui.preview_undo': 'Vorschau: Würde {count} Operation(en) rückgängig machen:',
+      'ui.current_language': 'Aktuelle Sprache: {name} ({code})',
+      'ui.available_languages': 'Verfügbare Sprachen:',
+      'ui.language_usage': 'Verwendung: ccundo language <code>',
+      
+      // Additional messages
+      'msg.redo_not_implemented': 'Wiederherstellen für lokale Verfolgung ist noch nicht implementiert.',
+      'msg.redo_cancelled': 'Wiederherstellen abgebrochen.',
+      'msg.switched_to_session': 'Zu Sitzung gewechselt: {sessionId}',
+      
+      // Tips
+      'tip.perform_undos': 'Um diese Rückgängigmachungen tatsächlich durchzuführen, führe aus: ccundo undo',
+      
+      // Cascading warnings
+      'prompt.cascading_redo_warning': 'Kaskadierendes Wiederherstellen: Das Auswählen einer Operation stellt diese und ALLE rückgängig gemachten Operationen davor wieder her.',
+      
+      // Backup and file operations (New i18n keys)
+      'msg.backup_saved_to': 'Sicherung gespeichert in: {path}',
+      
+      // Preview messages (New i18n keys)
+      'preview.string_replacements_reversed': 'Zeichenkette-Ersetzungen zum Rückgängigmachen:',
+      'preview.string_replacement_reversed': 'Zeichenkette-Ersetzung zum Rückgängigmachen:',
+      'preview.all_occurrences': ' (alle Vorkommen)',
+      'preview.context': 'Kontext:',
+      
+      // Additional error messages (New i18n keys)
+      'error.unknown_operation': 'Unbekannte Operation: {type}',
+      'error.file_not_exist': 'Datei existiert nicht:',
+      'error.reading_file': 'Fehler beim Lesen der Datei:',
+      'error.unknown_operation_type': 'Unbekannter Operationstyp: {type}',
+      'error.unsupported_language': 'Nicht unterstützte Sprache: {language}',
+      
+      // Additional status messages (New i18n keys)
+      'status.directory_already_removed': 'Verzeichnis bereits entfernt:',
+      
+      // UndoManager success messages (New i18n keys)
+      'undo.file_deleted': 'Datei gelöscht: {path}',
+      'undo.file_edit_reverted': 'Dateibearbeitung rückgängig gemacht: {path}',
+      'undo.file_restored': 'Datei wiederhergestellt: {path}',
+      'undo.file_renamed_back': 'Datei zurück umbenannt: {oldPath} → {newPath}',
+      'undo.directory_removed': 'Verzeichnis entfernt: {path}',
+      'undo.directory_restored': 'Verzeichnis wiederhergestellt: {path}',
+      
+      // UndoManager failure messages (New i18n keys)
+      'undo.failed_file_creation': 'Fehler beim Rückgängigmachen der Dateierstellung: {error}',
+      'undo.failed_file_edit': 'Fehler beim Rückgängigmachen der Dateibearbeitung: {error}',
+      'undo.failed_file_restore': 'Fehler beim Wiederherstellen der Datei: {error}',
+      'undo.failed_rename': 'Fehler beim Rückgängigmachen der Umbenennung: {error}',
+      'undo.failed_remove_directory': 'Fehler beim Entfernen des Verzeichnisses: {error}',
+      'undo.failed_restore_directory': 'Fehler beim Wiederherstellen des Verzeichnisses: {error}',
+      'undo.cannot_undo_edit': 'Bearbeitung kann nicht rückgängig gemacht werden: erwartete Zeichenkette nicht gefunden in {path}',
+      'undo.cannot_undo_edit_insufficient': 'Dateibearbeitung kann nicht rückgängig gemacht werden: unzureichende Daten für {path}',
+      'undo.cannot_restore_file': 'Datei kann nicht wiederhergestellt werden: Inhalt nicht verfügbar für {path}',
+      'undo.cannot_undo_bash': 'Bash-Befehl kann nicht automatisch rückgängig gemacht werden: {command}\nBitte machen Sie die Änderungen manuell rückgängig.',
+
+      // RedoManager success messages (New i18n keys)
+      'redo.file_recreated': 'Datei neu erstellt: {path}',
+      'redo.file_edit_redone': 'Dateibearbeitung wiederholt: {path}',
+      'redo.file_deleted_again': 'Datei erneut gelöscht: {path}',
+      'redo.file_renamed_again': 'Datei erneut umbenannt: {oldPath} → {newPath}',
+      'redo.directory_created_again': 'Verzeichnis erneut erstellt: {path}',
+      'redo.directory_deleted_again': 'Verzeichnis erneut gelöscht: {path}',
+
+      // RedoManager failure messages (New i18n keys)
+      'redo.cannot_redo_file_exists': 'Dateierstellung kann nicht wiederholt werden: {path} existiert bereits',
+      'redo.cannot_redo_no_content': 'Dateierstellung kann nicht wiederholt werden: kein Inhalt verfügbar für {path}',
+      'redo.failed_file_creation': 'Fehler beim Wiederholen der Dateierstellung: {error}',
+      'redo.cannot_redo_legacy_edit': 'Legacy-Dateibearbeitung kann nicht wiederholt werden: unzureichende Daten für {path}',
+      'redo.cannot_redo_edit': 'Bearbeitung kann nicht wiederholt werden: ursprüngliche Zeichenkette nicht gefunden in {path}',
+      'redo.cannot_redo_edit_insufficient': 'Dateibearbeitung kann nicht wiederholt werden: unzureichende Daten für {path}',
+      'redo.failed_file_edit': 'Fehler beim Wiederholen der Dateibearbeitung: {error}',
+      'redo.cannot_redo_file_not_exist': 'Dateilöschung kann nicht wiederholt werden: {path} existiert nicht',
+      'redo.failed_file_deletion': 'Fehler beim Wiederholen der Dateilöschung: {error}',
+      'redo.cannot_redo_rename_not_exist': 'Umbenennung kann nicht wiederholt werden: {path} existiert nicht',
+      'redo.cannot_redo_rename_exists': 'Umbenennung kann nicht wiederholt werden: {path} existiert bereits',
+      'redo.failed_rename': 'Fehler beim Wiederholen der Umbenennung: {error}',
+      'redo.cannot_redo_dir_exists': 'Verzeichniserstellung kann nicht wiederholt werden: {path} existiert bereits',
+      'redo.failed_directory_creation': 'Fehler beim Wiederholen der Verzeichniserstellung: {error}',
+      'redo.cannot_redo_dir_not_exist': 'Verzeichnislöschung kann nicht wiederholt werden: {path} existiert nicht',
+      'redo.failed_directory_deletion': 'Fehler beim Wiederholen der Verzeichnislöschung: {error}',
+      'redo.cannot_redo_bash': 'Bash-Befehl kann nicht wiederholt werden: {command}\nBitte führen Sie den Befehl manuell erneut aus.',
+
+      // Additional UI messages (New i18n keys)
+      'ui.more_will_be_undone': ' (+ {count} weitere werden rückgängig gemacht)',
+      'ui.more_will_be_redone': ' (+ {count} weitere werden wiederholt)',
+      'ui.more_would_be_undone': ' (+ {count} weitere würden rückgängig gemacht)',
+      'ui.more_lines': '... ({count} weitere Zeilen)',
+      'ui.unknown_language': 'Unbekannt'
     }
   },
 
   zh: {
     name: '简体中文',
     messages: {
+      // Program description
+      'program.description': '撤销 Claude Code 会话中执行的单个步骤',
+      
       // Command descriptions
       'cmd.list.description': '列出当前 Claude Code 会话中的所有操作',
       'cmd.undo.description': '撤销当前 Claude Code 会话中的操作',
@@ -487,6 +1045,8 @@ export const languages = {
       'opt.claude': '显示 Claude Code 会话的操作（默认）',
       'opt.local': '显示本地 ccundo 跟踪的操作',
       'opt.yes': '跳过确认',
+      'opt.local_tracking': '使用本地 ccundo 跟踪而不是 Claude 会话',
+      'opt.show_local_sessions': '显示本地 ccundo 会话而不是 Claude 会话',
 
       // Messages
       'msg.no_active_session': '在此目录中未找到活动的 Claude Code 会话。',
@@ -559,18 +1119,127 @@ export const languages = {
       // Suffixes
       'suffix.more_operations': '（+ 还将撤销 {count} 个操作）',
       'suffix.more_would_be_undone': '（+ 还将撤销 {count} 个操作）',
-      'suffix.tip_to_undo': '💡 要实际执行这些撤销，请运行：ccundo undo'
+      'suffix.tip_to_undo': '💡 要实际执行这些撤销，请运行：ccundo undo',
+      
+      // Labels
+      'label.file': '文件',
+      'label.from': '从',
+      'label.to': '到',
+      'label.directory': '目录',
+      'label.command': '命令',
+      'label.project': '项目',
+      
+      // Error messages
+      'error.operation_not_found': '未找到操作 {id}。',
+      'error.save_config_failed': '保存语言配置失败：',
+      'error.track_operation_failed': '跟踪操作失败：',
+      'error.general': '错误：{message}',
+      
+      // UI messages
+      'ui.undo_preview_header': '这将撤销 {count} 个操作：',
+      'ui.undoing_operations': '正在撤销 {count} 个操作...',
+      'ui.preview_undo': '预览：将撤销 {count} 个操作：',
+      'ui.current_language': '当前语言：{name} ({code})',
+      'ui.available_languages': '可用语言：',
+      'ui.language_usage': '用法：ccundo language <code>',
+      
+      // Additional messages
+      'msg.redo_not_implemented': '本地跟踪的重做功能尚未实现。',
+      'msg.redo_cancelled': '重做已取消。',
+      'msg.switched_to_session': '已切换到会话：{sessionId}',
+      
+      // Tips
+      'tip.perform_undos': '要实际执行这些撤销，请运行：ccundo undo',
+      
+      // Cascading warnings
+      'prompt.cascading_redo_warning': '级联重做：选择一个操作将重做该操作以及之前的所有撤销操作。',
+      
+      // Backup and file operations (New i18n keys)
+      'msg.backup_saved_to': '备份已保存到：{path}',
+      
+      // Preview messages (New i18n keys)
+      'preview.string_replacements_reversed': '将要撤销的字符串替换：',
+      'preview.string_replacement_reversed': '将要撤销的字符串替换：',
+      'preview.all_occurrences': '（所有匹配项）',
+      'preview.context': '上下文：',
+      
+      // Additional error messages (New i18n keys)
+      'error.unknown_operation': '未知操作：{type}',
+      'error.file_not_exist': '文件不存在：',
+      'error.reading_file': '读取文件错误：',
+      'error.unknown_operation_type': '未知操作类型：{type}',
+      'error.unsupported_language': '不支持的语言：{language}',
+      
+      // Additional status messages (New i18n keys)
+      'status.directory_already_removed': '目录已被删除：',
+      
+      // UndoManager success messages (New i18n keys)
+      'undo.file_deleted': '文件已删除：{path}',
+      'undo.file_edit_reverted': '文件编辑已撤销：{path}',
+      'undo.file_restored': '文件已恢复：{path}',
+      'undo.file_renamed_back': '文件已重命名回：{oldPath} → {newPath}',
+      'undo.directory_removed': '目录已删除：{path}',
+      'undo.directory_restored': '目录已恢复：{path}',
+      
+      // UndoManager failure messages (New i18n keys)
+      'undo.failed_file_creation': '撤销文件创建失败：{error}',
+      'undo.failed_file_edit': '撤销文件编辑失败：{error}',
+      'undo.failed_file_restore': '恢复文件失败：{error}',
+      'undo.failed_rename': '撤销重命名失败：{error}',
+      'undo.failed_remove_directory': '删除目录失败：{error}',
+      'undo.failed_restore_directory': '恢复目录失败：{error}',
+      'undo.cannot_undo_edit': '无法撤销编辑：在 {path} 中未找到预期字符串',
+      'undo.cannot_undo_edit_insufficient': '无法撤销文件编辑：{path} 数据不足',
+      'undo.cannot_restore_file': '无法恢复文件：{path} 内容不可用',
+      'undo.cannot_undo_bash': '无法自动撤销 bash 命令：{command}\n请手动撤销更改。',
+
+      // RedoManager success messages (New i18n keys)
+      'redo.file_recreated': '文件已重新创建：{path}',
+      'redo.file_edit_redone': '文件编辑已重做：{path}',
+      'redo.file_deleted_again': '文件已再次删除：{path}',
+      'redo.file_renamed_again': '文件已再次重命名：{oldPath} → {newPath}',
+      'redo.directory_created_again': '目录已再次创建：{path}',
+      'redo.directory_deleted_again': '目录已再次删除：{path}',
+
+      // RedoManager failure messages (New i18n keys)
+      'redo.cannot_redo_file_exists': '无法重做文件创建：{path} 已存在',
+      'redo.cannot_redo_no_content': '无法重做文件创建：{path} 内容不可用',
+      'redo.failed_file_creation': '重做文件创建失败：{error}',
+      'redo.cannot_redo_legacy_edit': '无法重做旧版文件编辑：{path} 数据不足',
+      'redo.cannot_redo_edit': '无法重做编辑：在 {path} 中未找到原始字符串',
+      'redo.cannot_redo_edit_insufficient': '无法重做文件编辑：{path} 数据不足',
+      'redo.failed_file_edit': '重做文件编辑失败：{error}',
+      'redo.cannot_redo_file_not_exist': '无法重做文件删除：{path} 不存在',
+      'redo.failed_file_deletion': '重做文件删除失败：{error}',
+      'redo.cannot_redo_rename_not_exist': '无法重做重命名：{path} 不存在',
+      'redo.cannot_redo_rename_exists': '无法重做重命名：{path} 已存在',
+      'redo.failed_rename': '重做重命名失败：{error}',
+      'redo.cannot_redo_dir_exists': '无法重做目录创建：{path} 已存在',
+      'redo.failed_directory_creation': '重做目录创建失败：{error}',
+      'redo.cannot_redo_dir_not_exist': '无法重做目录删除：{path} 不存在',
+      'redo.failed_directory_deletion': '重做目录删除失败：{error}',
+      'redo.cannot_redo_bash': '无法重做 bash 命令：{command}\n请手动重新运行命令。',
+
+      // Additional UI messages (New i18n keys)
+      'ui.more_will_be_undone': '（+ 还将撤销 {count} 个操作）',
+      'ui.more_will_be_redone': '（+ 还将重做 {count} 个操作）',
+      'ui.more_would_be_undone': '（+ 还将撤销 {count} 个操作）',
+      'ui.more_lines': '... （还有 {count} 行）',
+      'ui.unknown_language': '未知'
     }
   },
 
   tw: {
     name: '繁體中文',
     messages: {
+      // Program description
+      'program.description': '撤銷 Claude Code 會話中執行的單個步驟',
+      
       // Command descriptions
       'cmd.list.description': '列出目前 Claude Code 會話中的所有操作',
       'cmd.undo.description': '撤銷目前 Claude Code 會話中的操作',
       'cmd.redo.description': '重做之前撤銷的操作',
-      'cmd.preview.description': '預覽將要撤銷的內容，但不進行更改',
+      'cmd.preview.description': '預覽將要撤銷的內容，但不作更改',
       'cmd.sessions.description': '列出所有可用的 Claude Code 會話',
       'cmd.session.description': '切換到不同的會話',
       'cmd.language.description': '設定介面語言',
@@ -579,8 +1248,10 @@ export const languages = {
       'opt.all': '顯示所有操作，包括已撤銷的',
       'opt.session': '指定會話 ID',
       'opt.claude': '顯示 Claude Code 會話的操作（預設）',
-      'opt.local': '顯示本地 ccundo 跟踪的操作',
+      'opt.local': '顯示本地 ccundo 跟蹤的操作',
       'opt.yes': '跳過確認',
+      'opt.local_tracking': '使用本地 ccundo 跟蹤而不是 Claude 會話',
+      'opt.show_local_sessions': '顯示本地 ccundo 會話而不是 Claude 會話',
 
       // Messages
       'msg.no_active_session': '在此目錄中未找到活動的 Claude Code 會話。',
@@ -653,7 +1324,113 @@ export const languages = {
       // Suffixes
       'suffix.more_operations': '（+ 還將撤銷 {count} 個操作）',
       'suffix.more_would_be_undone': '（+ 還將撤銷 {count} 個操作）',
-      'suffix.tip_to_undo': '💡 要實際執行這些撤銷，請運行：ccundo undo'
+      'suffix.tip_to_undo': '💡 要實際執行這些撤銷，請運行：ccundo undo',
+      
+      // Labels
+      'label.file': '文件',
+      'label.from': '從',
+      'label.to': '到',
+      'label.directory': '目錄',
+      'label.command': '命令',
+      'label.project': '專案',
+      
+      // Error messages
+      'error.operation_not_found': '未找到操作 {id}。',
+      'error.save_config_failed': '儲存語言設定失敗：',
+      'error.track_operation_failed': '追蹤操作失敗：',
+      'error.general': '錯誤：{message}',
+      
+      // UI messages
+      'ui.undo_preview_header': '這將撤銷 {count} 個操作：',
+      'ui.undoing_operations': '正在撤銷 {count} 個操作...',
+      'ui.preview_undo': '預覽：將撤銷 {count} 個操作：',
+      'ui.current_language': '目前語言：{name} ({code})',
+      'ui.available_languages': '可用語言：',
+      'ui.language_usage': '用法：ccundo language <code>',
+      
+      // Additional messages
+      'msg.redo_not_implemented': '本地追蹤的重做功能尚未實現。',
+      'msg.redo_cancelled': '重做已取消。',
+      'msg.switched_to_session': '已切換到會話：{sessionId}',
+      
+      // Tips
+      'tip.perform_undos': '要實際執行這些撤銷，請運行：ccundo undo',
+      
+      // Cascading warnings
+      'prompt.cascading_redo_warning': '級聯重做：選擇一個操作將重做該操作以及之前的所有撤銷操作。',
+      
+      // Backup and file operations (New i18n keys)
+      'msg.backup_saved_to': '備份已儲存至：{path}',
+      
+      // Preview messages (New i18n keys)
+      'preview.string_replacements_reversed': '將要撤銷的字串替換：',
+      'preview.string_replacement_reversed': '將要撤銷的字串替換：',
+      'preview.all_occurrences': '（所有符合項）',
+      'preview.context': '上下文：',
+      
+      // Additional error messages (New i18n keys)
+      'error.unknown_operation': '未知操作：{type}',
+      'error.file_not_exist': '檔案不存在：',
+      'error.reading_file': '讀取檔案錯誤：',
+      'error.unknown_operation_type': '未知操作類型：{type}',
+      'error.unsupported_language': '不支援的語言：{language}',
+      
+      // Additional status messages (New i18n keys)
+      'status.directory_already_removed': '目錄已被刪除：',
+      
+      // UndoManager success messages (New i18n keys)
+      'undo.file_deleted': '檔案已刪除：{path}',
+      'undo.file_edit_reverted': '檔案編輯已撤銷：{path}',
+      'undo.file_restored': '檔案已恢復：{path}',
+      'undo.file_renamed_back': '檔案已重新命名回：{oldPath} → {newPath}',
+      'undo.directory_removed': '目錄已刪除：{path}',
+      'undo.directory_restored': '目錄已恢復：{path}',
+      
+      // UndoManager failure messages (New i18n keys)
+      'undo.failed_file_creation': '撤銷檔案建立失敗：{error}',
+      'undo.failed_file_edit': '撤銷檔案編輯失敗：{error}',
+      'undo.failed_file_restore': '恢復檔案失敗：{error}',
+      'undo.failed_rename': '撤銷重新命名失敗：{error}',
+      'undo.failed_remove_directory': '刪除目錄失敗：{error}',
+      'undo.failed_restore_directory': '恢復目錄失敗：{error}',
+      'undo.cannot_undo_edit': '無法撤銷編輯：在 {path} 中未找到預期字串',
+      'undo.cannot_undo_edit_insufficient': '無法撤銷檔案編輯：{path} 資料不足',
+      'undo.cannot_restore_file': '無法恢復檔案：{path} 內容不可用',
+      'undo.cannot_undo_bash': '無法自動撤銷 bash 命令：{command}\n請手動撤銷更改。',
+
+      // RedoManager success messages (New i18n keys)
+      'redo.file_recreated': '檔案已重新建立：{path}',
+      'redo.file_edit_redone': '檔案編輯已重做：{path}',
+      'redo.file_deleted_again': '檔案已再次刪除：{path}',
+      'redo.file_renamed_again': '檔案已再次重新命名：{oldPath} → {newPath}',
+      'redo.directory_created_again': '目錄已再次建立：{path}',
+      'redo.directory_deleted_again': '目錄已再次刪除：{path}',
+
+      // RedoManager failure messages (New i18n keys)
+      'redo.cannot_redo_file_exists': '無法重做檔案建立：{path} 已存在',
+      'redo.cannot_redo_no_content': '無法重做檔案建立：{path} 內容不可用',
+      'redo.failed_file_creation': '重做檔案建立失敗：{error}',
+      'redo.cannot_redo_legacy_edit': '無法重做舊版檔案編輯：{path} 資料不足',
+      'redo.cannot_redo_edit': '無法重做編輯：在 {path} 中未找到原始字串',
+      'redo.cannot_redo_edit_insufficient': '無法重做檔案編輯：{path} 資料不足',
+      'redo.failed_file_edit': '重做檔案編輯失敗：{error}',
+      'redo.cannot_redo_file_not_exist': '無法重做檔案刪除：{path} 不存在',
+      'redo.failed_file_deletion': '重做檔案刪除失敗：{error}',
+      'redo.cannot_redo_rename_not_exist': '無法重做重新命名：{path} 不存在',
+      'redo.cannot_redo_rename_exists': '無法重做重新命名：{path} 已存在',
+      'redo.failed_rename': '重做重新命名失敗：{error}',
+      'redo.cannot_redo_dir_exists': '無法重做目錄建立：{path} 已存在',
+      'redo.failed_directory_creation': '重做目錄建立失敗：{error}',
+      'redo.cannot_redo_dir_not_exist': '無法重做目錄刪除：{path} 不存在',
+      'redo.failed_directory_deletion': '重做目錄刪除失敗：{error}',
+      'redo.cannot_redo_bash': '無法重做 bash 命令：{command}\n請手動重新執行命令。',
+
+      // Additional UI messages (New i18n keys)
+      'ui.more_will_be_undone': '（+ 還將撤銷 {count} 個操作）',
+      'ui.more_will_be_redone': '（+ 還將重做 {count} 個操作）',
+      'ui.more_would_be_undone': '（+ 還將撤銷 {count} 個操作）',
+      'ui.more_lines': '... （還有 {count} 行）',
+      'ui.unknown_language': '未知'
     }
   }
 };


### PR DESCRIPTION
## Based on PR #10
This PR builds upon the Chinese internationalization foundation established in [PR #10](https://github.com/RonitSachdev/ccundo/pull/10) by @cc3389, extending it to achieve complete project internationalization.

## Summary
Complete internationalization support by replacing all hard-coded logs and messages with i18n calls, building upon the Chinese translation support from PR #10.

## Changes Made
- 🌍 Convert all hard-coded messages and logs to i18n calls
- 📝 Update README.md to reflect i18n functionality  
- 🔧 Modify core components to support multilingual:
  - `bin/ccundo.js` - Main CLI interface
  - `src/core/OperationPreview.js` - Operation preview component
  - `src/core/RedoManager.js` - Redo manager
  - `src/core/UndoManager.js` - Undo manager
  - `src/hooks/claude-tracker.js` - Claude tracker hook
- 📖 Extend language files with extensive translation entries based on the Chinese foundation
- 🐛 Fix minor issues in i18n configuration

## Files Modified
- `README.md` - Documentation updates
- `bin/ccundo.js` - Main program internationalization (139 lines modified)
- `src/core/OperationPreview.js` - Preview functionality internationalization
- `src/core/RedoManager.js` - Redo functionality internationalization  
- `src/core/UndoManager.js` - Undo functionality internationalization
- `src/hooks/claude-tracker.js` - Hook internationalization
- `src/i18n/i18n.js` - i18n configuration improvements
- `src/i18n/languages.js` - Massive addition of translation entries (+795 lines)

## Relationship to PR #10
- Extends the Chinese translation support from PR #10
- Uses the same i18n infrastructure established in PR #10
- Completes the internationalization work by converting all remaining hard-coded strings

## Test Plan  
- [x] Test all CLI commands output in different languages
- [x] Verify localized display of error messages
- [x] Confirm all user interface text has been internationalized
- [x] Ensure compatibility with Chinese translations from PR #10

This PR transforms the entire project to be fully internationalized, building upon the excellent Chinese translation foundation from PR #10.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>