### PR TITLE
Add support for MCP Filesystem tools

### DIFF
--- a/src/core/ClaudeSessionParser.js
+++ b/src/core/ClaudeSessionParser.js
@@ -93,7 +93,7 @@ export class ClaudeSessionParser {
 
   extractOperation(toolUse, timestamp) {
     const { name, input } = toolUse;
-    
+
     switch (name) {
       case 'Write':
         if (input.file_path) {
@@ -123,6 +123,31 @@ export class ClaudeSessionParser {
         }
         break;
         
+      case 'mcp__filesystem__write_file':
+        if (input.path) {
+          const op = new Operation(OperationType.FILE_CREATE, {
+            filePath: input.path,
+            content: input.content || ''
+          });
+          op.timestamp = new Date(timestamp);
+          op.id = toolUse.id;
+          return op;
+        }
+        break;
+
+      case 'mcp__filesystem__edit_file':
+        if (input.path) {
+          const op = new Operation(OperationType.FILE_EDIT, {
+            filePath: input.path,
+            edits: input.edits || [],
+            isMCPEdit: true
+          });
+          op.timestamp = new Date(timestamp);
+          op.id = toolUse.id;
+          return op;
+        }
+        break;
+
       case 'MultiEdit':
         if (input.file_path) {
           // For MultiEdit, we have multiple edits but still just the strings

--- a/src/core/ClaudeSessionParser.js
+++ b/src/core/ClaudeSessionParser.js
@@ -148,6 +148,17 @@ export class ClaudeSessionParser {
         }
         break;
 
+      case 'mcp__filesystem__create_directory':
+        if (input.path) {
+          const op = new Operation(OperationType.DIRECTORY_CREATE, {
+            dirPath: input.path
+          });
+          op.timestamp = new Date(timestamp);
+          op.id = toolUse.id;
+          return op;
+        }
+        break;
+
       case 'MultiEdit':
         if (input.file_path) {
           // For MultiEdit, we have multiple edits but still just the strings

--- a/src/core/RedoManager.js
+++ b/src/core/RedoManager.js
@@ -77,7 +77,7 @@ export class RedoManager {
   }
 
   async redoFileEdit(operation) {
-    const { filePath, originalContent, oldString, newString, replaceAll, edits, isMultiEdit } = operation.data;
+    const { filePath, originalContent, oldString, newString, replaceAll, edits, isMultiEdit, isMCPEdit } = operation.data;
     
     try {
       const currentContent = await fs.readFile(filePath, 'utf8');
@@ -102,6 +102,14 @@ export class RedoManager {
             }
           }
         }
+      } else if (isMCPEdit && edits) {
+        for (const edit of edits) {
+          if (edit.oldText !== undefined && edit.newText) {
+            if (redoneContent.includes(edit.oldText)) {
+              redoneContent = redoneContent.replace(edit.oldText, edit.newText);
+            }
+          }
+      }
       } else if (oldString !== undefined && newString) {
         // Redo single Edit operation - apply the original string replacement
         if (replaceAll) {

--- a/src/core/UndoManager.js
+++ b/src/core/UndoManager.js
@@ -56,7 +56,7 @@ export class UndoManager {
   }
 
   async undoFileEdit(operation) {
-    const { filePath, originalContent, oldString, newString, replaceAll, edits, isMultiEdit } = operation.data;
+    const { filePath, originalContent, oldString, newString, replaceAll, edits, isMultiEdit, isMCPEdit } = operation.data;
     
     try {
       const currentContent = await fs.readFile(filePath, 'utf8');
@@ -76,6 +76,15 @@ export class UndoManager {
             // Try to replace new_string back with old_string
             if (revertedContent.includes(edit.new_string)) {
               revertedContent = revertedContent.replace(edit.new_string, edit.old_string);
+            }
+          }
+        }
+      } else if (isMCPEdit && edits) {
+        for (let i = edits.length - 1; i >= 0; i--) {
+          const edit = edits[i];
+          if (edit.newText && edit.oldText !== undefined) {
+            if (revertedContent.includes(edit.newText)) {
+              revertedContent = revertedContent.replace(edit.newText, edit.oldText);
             }
           }
         }


### PR DESCRIPTION
I was getting a `No operations found.` message because Claude Code was using MCP tool operations to edit and write files, but `ccundo` couldn't recognize them.

This contribution adds support for people using the popular [MCP Filesystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) in their environment, making it possible to list, undo, and redo the changes made by the following MCP operations:

* `mcp__filesystem__write_file`
* `mcp__filesystem__edit_file`
* `mcp__filesystem__create_directory`